### PR TITLE
feat: complete screen redesign — dashboard, post, settings, and UX polish

### DIFF
--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/AiService.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/AiService.java
@@ -289,6 +289,41 @@ public class AiService {
         void onFailure(String errorMessage);
     }
 
+    public void generateDashboardInsight(int todaySteps, int streakDays, int avgSteps7d, final TextResponseCallback callback) {
+        String prompt = "You are a fitness coach. Give one motivating, personalized fitness insight in exactly 1-2 short sentences. "
+                + "The user has walked " + todaySteps + " steps today, has a " + streakDays
+                + "-day streak, and averages " + avgSteps7d + " steps over the past 7 days. "
+                + "Be specific, positive, and actionable. Plain text only, no markdown.";
+        List<Map<String, Object>> contents = new ArrayList<>();
+        Map<String, Object> userMessage = new HashMap<>();
+        userMessage.put("parts", List.of(Map.of("text", prompt)));
+        contents.add(userMessage);
+        Map<String, Object> requestBodyMap = new HashMap<>();
+        requestBodyMap.put("contents", contents);
+        String requestJson = gson.toJson(requestBodyMap);
+        RequestBody requestBody = RequestBody.create(requestJson, MediaType.parse("application/json; charset=utf-8"));
+        Request request = new Request.Builder().url(API_URL).post(requestBody).build();
+        client.newCall(request).enqueue(new Callback() {
+            @Override
+            public void onFailure(Call call, IOException e) {
+                callback.onFailure("Network error: " + e.getMessage());
+            }
+            @Override
+            public void onResponse(Call call, Response response) throws IOException {
+                String responseBody = response.body().string();
+                if (response.isSuccessful()) {
+                    try {
+                        callback.onSuccess(parseSimpleTextResponse(responseBody).trim());
+                    } catch (Exception e) {
+                        callback.onFailure("Parse error: " + e.getMessage());
+                    }
+                } else {
+                    callback.onFailure("API error: " + response.code());
+                }
+            }
+        });
+    }
+
     public void translateText(String textToTranslate, final TextResponseCallback callback) {
         //String prompt = "Translate the following text into English. Provide only the translated text without any additional comments or introductions. The text is: \"" + textToTranslate + "\"";
         String prompt = "Identify the language of the following text. If the text is not English, translate it fully into English. If the text is already English, return it unchanged. Provide only the resulting English text, or the original English text if no translation was needed, without any additional comments or introductions. The text is: \"" + textToTranslate + "\"";

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/ApiManager.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/ApiManager.java
@@ -406,6 +406,29 @@ public class ApiManager {
         queue.add(pendRewardsRequest);
     }
 
+    public void displayEstimatedReward(RequestQueue queue, TextView tvEstimatedAfit) {
+        String username = sharedPreferences.getString("actifitUser", "");
+        if (username.isEmpty() || tvEstimatedAfit == null) return;
+
+        String rewardUrl = Utils.apiUrl(context) + context.getString(R.string.estimated_reward_api_url) + username;
+        JsonObjectRequest rewardRequest = new JsonObjectRequest(Request.Method.GET, rewardUrl, null, response -> {
+            try {
+                double estimatedAfit = response.optDouble("estimated_afit", 0);
+                boolean alreadyRewarded = response.optBoolean("already_rewarded", false);
+                String label;
+                if (alreadyRewarded) {
+                    label = String.format(java.util.Locale.getDefault(), "%.1f AFIT (last reward)", estimatedAfit);
+                } else {
+                    label = String.format(java.util.Locale.getDefault(), "~%.1f AFIT (estimated)", estimatedAfit);
+                }
+                ((Activity) context).runOnUiThread(() -> tvEstimatedAfit.setText(label));
+            } catch (Exception e) {
+                Log.e(TAG, "error parsing estimated reward");
+            }
+        }, error -> Log.e(TAG, "error fetching estimated reward"));
+        queue.add(rewardRequest);
+    }
+
     public void displayUserGadgets(RequestQueue queue, LinearLayout userGadgets, TextView noActiveGadgets) {
         String username = sharedPreferences.getString("actifitUser", "");
         if (username.isEmpty()) {

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/BaseActivity.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/BaseActivity.java
@@ -75,24 +75,24 @@ public class BaseActivity extends AppCompatActivity {
 
     protected void updateNavigationButtonStates() {
 
-        TextView btnHome = findViewById(R.id.btn_home);
+        View btnHome = findViewById(R.id.btn_home);
         if (btnHome != null){
             btnHome.setSelected(this instanceof MainActivity);
         }
 
-        TextView btnLeaderboard = findViewById(R.id.btn_view_leaderboard);
+        View btnLeaderboard = findViewById(R.id.btn_view_leaderboard);
         if (btnLeaderboard != null) {
-            btnLeaderboard.setSelected(this instanceof LeaderboardActivity); // Replace LeaderboardActivity
+            btnLeaderboard.setSelected(this instanceof LeaderboardActivity);
         }
 
-        TextView btnMarket = findViewById(R.id.btn_view_market);
+        View btnMarket = findViewById(R.id.btn_view_market);
         if (btnMarket != null) {
-            btnMarket.setSelected(this instanceof MarketActivity); // Replace LeaderboardActivity
+            btnMarket.setSelected(this instanceof MarketActivity);
         }
 
-        TextView btnViewSocial = findViewById(R.id.btn_view_social);
+        View btnViewSocial = findViewById(R.id.btn_view_social);
         if (btnViewSocial != null) {
-            btnViewSocial.setSelected(this instanceof SocialActivity); // Replace LeaderboardActivity
+            btnViewSocial.setSelected(this instanceof SocialActivity);
         }
 
         TextView btnStepHistory = findViewById(R.id.btn_view_history);
@@ -121,15 +121,16 @@ public class BaseActivity extends AppCompatActivity {
 
     protected void setupCommonActionButtons() {
 
-        TextView btnHome = findViewById(R.id.btn_home);
+        View btnHome = findViewById(R.id.btn_home);
         TextView btnSocials = findViewById(R.id.btn_socials);
         TextView btnChat = findViewById(R.id.btn_chat);
-        TextView btnLeaderboard = findViewById(R.id.btn_view_leaderboard);
+        View btnLeaderboard = findViewById(R.id.btn_view_leaderboard);
         TextView btnVideo = findViewById(R.id.btn_video);
         TextView btnHelp = findViewById(R.id.btn_help);
-        TextView btnMarket = findViewById(R.id.btn_view_market);
+        View btnMarket = findViewById(R.id.btn_view_market);
         TextView btnStepHistory = findViewById(R.id.btn_view_history);
-        TextView btnViewSocial = findViewById(R.id.btn_view_social);
+        View btnViewSocial = findViewById(R.id.btn_view_social);
+        View btnMoreFooter = findViewById(R.id.btn_more_footer);
         chatNotifCount = findViewById(R.id.chat_notif_count);
 
 
@@ -314,7 +315,6 @@ public class BaseActivity extends AppCompatActivity {
             });
         }
 
-        TextView btnMoreFooter = findViewById(R.id.btn_more_footer);
         if (btnMoreFooter != null) {
             btnMoreFooter.setOnClickListener(v -> showMoreMenu());
         }

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/BaseActivity.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/BaseActivity.java
@@ -310,11 +310,14 @@ public class BaseActivity extends AppCompatActivity {
             btnVideo.setOnClickListener(arg0 -> {
                 //show video modal
                 VideoUploadFragment dialog = new VideoUploadFragment(this, LoginActivity.accessToken, this, false);
-                //dialog.getView().setMinimumWidth(400);
                 dialog.show(getSupportFragmentManager(), "video_upload_fragment");
             });
         }
 
+        TextView btnMoreFooter = findViewById(R.id.btn_more_footer);
+        if (btnMoreFooter != null) {
+            btnMoreFooter.setOnClickListener(v -> showMoreMenu());
+        }
 
         new Thread(() -> {
             runOnUiThread(() -> {
@@ -325,6 +328,60 @@ public class BaseActivity extends AppCompatActivity {
         }).start();
 
         updateNavigationButtonStates(); // Highlight the current activity's button
+    }
+
+    protected void showMoreMenu() {
+        com.google.android.material.bottomsheet.BottomSheetDialog sheet =
+                new com.google.android.material.bottomsheet.BottomSheetDialog(this);
+        android.view.View sheetView = getLayoutInflater().inflate(R.layout.bottom_sheet_more_menu, null);
+        sheet.setContentView(sheetView);
+
+        sheetView.findViewById(R.id.more_item_history).setOnClickListener(v -> {
+            sheet.dismiss();
+            if (!(this instanceof StepHistoryActivity))
+                startActivity(new Intent(this, StepHistoryActivity.class));
+        });
+        sheetView.findViewById(R.id.more_item_videos).setOnClickListener(v -> {
+            sheet.dismiss();
+            VideoUploadFragment vd = new VideoUploadFragment(this, LoginActivity.accessToken, this, false);
+            vd.show(getSupportFragmentManager(), "video_upload_fragment");
+        });
+        sheetView.findViewById(R.id.more_item_socials).setOnClickListener(v -> {
+            sheet.dismiss();
+            AlertDialog.Builder b = new AlertDialog.Builder(this);
+            android.view.View socialLayout = getLayoutInflater().inflate(R.layout.social_actifit, null);
+            socialLayout.findViewById(R.id.facebook_actifit).setOnClickListener(v2 -> { try { startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.facebook_actifit)))); } catch (Exception ignored) {} });
+            socialLayout.findViewById(R.id.twitter_actifit).setOnClickListener(v2 -> { try { startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.twitter_actifit)))); } catch (Exception ignored) {} });
+            socialLayout.findViewById(R.id.telegram_actifit).setOnClickListener(v2 -> { try { startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.telegram_actifit)))); } catch (Exception ignored) {} });
+            socialLayout.findViewById(R.id.discord_actifit).setOnClickListener(v2 -> { try { startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.discord_actifit)))); } catch (Exception ignored) {} });
+            socialLayout.findViewById(R.id.instagram_actifit).setOnClickListener(v2 -> { try { startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.instagram_actifit)))); } catch (Exception ignored) {} });
+            socialLayout.findViewById(R.id.linkedin_actifit).setOnClickListener(v2 -> { try { startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.linkedin_actifit)))); } catch (Exception ignored) {} });
+            socialLayout.findViewById(R.id.youtube_actifit).setOnClickListener(v2 -> { try { startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.youtube_actifit)))); } catch (Exception ignored) {} });
+            b.setView(socialLayout).setTitle(getString(R.string.socials_note))
+                    .setIcon(getResources().getDrawable(R.drawable.actifit_logo))
+                    .setPositiveButton(getString(R.string.close_button), null).show();
+        });
+        sheetView.findViewById(R.id.more_item_help).setOnClickListener(v -> {
+            sheet.dismiss();
+            if (tutVidUrl[0] != null && !tutVidUrl[0].isEmpty()) {
+                try {
+                    Intent i = new Intent(Intent.ACTION_VIEW, Uri.parse(tutVidUrl[0]));
+                    i.setPackage("com.google.android.youtube");
+                    startActivity(i);
+                } catch (android.content.ActivityNotFoundException e) {
+                    try { startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(tutVidUrl[0]))); }
+                    catch (Exception ignored) {}
+                }
+            }
+        });
+        sheetView.findViewById(R.id.more_item_chat).setOnClickListener(v -> {
+            sheet.dismiss();
+            storeNotifDate(new Date(), "");
+            storeNotifCount(lastChatCount);
+            ChatDialogFragment.newInstance(this).show(getSupportFragmentManager(), "chat_dialog");
+        });
+
+        sheet.show();
     }
 
 

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/ChartManager.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/ChartManager.java
@@ -17,7 +17,6 @@ import android.widget.Toast;
 import androidx.core.content.ContextCompat;
 
 import com.github.mikephil.charting.charts.BarChart;
-import com.github.mikephil.charting.charts.PieChart;
 import com.github.mikephil.charting.components.Description;
 import com.github.mikephil.charting.components.Legend;
 import com.github.mikephil.charting.components.LimitLine;
@@ -27,13 +26,10 @@ import com.github.mikephil.charting.data.BarData;
 import com.github.mikephil.charting.data.BarDataSet;
 import com.github.mikephil.charting.data.BarEntry;
 import com.github.mikephil.charting.data.Entry;
-import com.github.mikephil.charting.data.PieData;
-import com.github.mikephil.charting.data.PieDataSet;
-import com.github.mikephil.charting.data.PieEntry;
 import com.github.mikephil.charting.formatter.IAxisValueFormatter;
 import com.github.mikephil.charting.formatter.IValueFormatter;
-import com.github.mikephil.charting.utils.ColorTemplate;
 import com.github.mikephil.charting.utils.ViewPortHandler;
+import com.google.android.material.progressindicator.CircularProgressIndicator;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -52,9 +48,11 @@ public class ChartManager {
 
     private final Context context;
 
-    private PieChart btnPieChart;
-    private PieChart fitbitPieChart;
-    private PieChart healthConnectPieChart;
+    private CircularProgressIndicator stepRing;
+    private CircularProgressIndicator stepRingFitbit;
+    private CircularProgressIndicator stepRingHc;
+
+    private static final int DAILY_GOAL = 10000;
 
     private BarChart dayChart, fullChart;
     private BarData chartBarData, dayBarData;
@@ -102,10 +100,6 @@ public class ChartManager {
         this.chartSwitcher = chartSwitcher;
     }
 
-    public PieChart getBtnPieChart() {
-        return btnPieChart;
-    }
-
     public BarChart getDayChart() {
         return dayChart;
     }
@@ -122,11 +116,39 @@ public class ChartManager {
         return dayBarData;
     }
 
+    private void updateRing(CircularProgressIndicator ring, android.widget.TextView tvCount,
+                            android.widget.TextView tvGoal, android.widget.TextView tvPct,
+                            int stepCount, boolean animate) {
+        int steps = Math.max(stepCount, 0);
+        int progress = Math.min((steps * 100) / DAILY_GOAL, 100);
+        int color = steps >= activityMilestoneOne
+                ? ContextCompat.getColor(context, R.color.actifitDarkGreen)
+                : ContextCompat.getColor(context, R.color.actifitRed);
+
+        ring.setIndicatorColor(color);
+        if (animate) {
+            ring.setProgressCompat(progress, true);
+        } else {
+            ring.setProgress(progress, false);
+        }
+
+        if (tvCount != null) {
+            tvCount.setText(java.text.NumberFormat.getInstance().format(steps));
+            tvCount.setTextColor(color);
+        }
+        if (tvGoal != null) tvGoal.setText("/ " + java.text.NumberFormat.getInstance().format(DAILY_GOAL) + " steps");
+        if (tvPct != null) tvPct.setText(progress + "% to goal");
+    }
+
     public void displayActivityChart(final int stepCount, final boolean animate) {
         ((android.app.Activity) context).runOnUiThread(() -> {
-            btnPieChart = ((android.app.Activity) context).findViewById(R.id.step_pie_chart);
-            ArrayList<PieEntry> activityArray = new ArrayList();
-            activityArray.add(new PieEntry(stepCount, ""));
+            stepRing = ((android.app.Activity) context).findViewById(R.id.step_ring);
+            android.widget.TextView tvCount = ((android.app.Activity) context).findViewById(R.id.tv_step_count);
+            android.widget.TextView tvGoal = ((android.app.Activity) context).findViewById(R.id.tv_step_goal);
+            android.widget.TextView tvPct = ((android.app.Activity) context).findViewById(R.id.tv_step_pct);
+            if (stepRing == null) return;
+
+            updateRing(stepRing, tvCount, tvGoal, tvPct, stepCount, animate);
 
             if (stepCount > 2000) {
                 if (BtnWaves != null && (BtnWaves.getAnimation() == null || !BtnWaves.getAnimation().hasStarted())) {
@@ -135,175 +157,72 @@ public class ChartManager {
             } else {
                 if (BtnWaves != null) BtnWaves.clearAnimation();
             }
-
-            if (stepCount < activityMilestoneOne) {
-                activityArray.add(new PieEntry(activityMilestoneOne - stepCount, ""));
-                activityArray.add(new PieEntry(activityMilestoneOne, ""));
-            } else if (stepCount < activityMilestoneThree) {
+            if (stepCount >= activityMilestoneOne && stepCount < activityMilestoneThree) {
                 if (BtnPostSteemit != null && scaler != null) {
                     if (BtnPostSteemit.getAnimation() == null || BtnPostSteemit.getAnimation().hasStarted()) {
                         BtnPostSteemit.startAnimation(scaler);
                     }
                 }
-                activityArray.add(new PieEntry(activityMilestoneThree - stepCount, ""));
-            } else {
+            } else if (stepCount >= activityMilestoneThree) {
                 if (BtnPostSteemit != null) BtnPostSteemit.clearAnimation();
-            }
-
-            PieDataSet dataSet = new PieDataSet(activityArray, "");
-            PieData data = new PieData(dataSet);
-            btnPieChart.setData(data);
-            btnPieChart.getDescription().setEnabled(false);
-            btnPieChart.setCenterText("" + (Math.max(stepCount, 0)));
-            btnPieChart.setCenterTextColor(context.getResources().getColor(R.color.actifitRed));
-            btnPieChart.setCenterTextSize(20f);
-            btnPieChart.setEntryLabelColor(ColorTemplate.COLOR_NONE);
-            btnPieChart.setDrawEntryLabels(false);
-            btnPieChart.getLegend().setEnabled(false);
-
-            if (stepCount < activityMilestoneOne) {
-                dataSet.setColors(context.getResources().getColor(R.color.actifitRed),
-                        context.getResources().getColor(android.R.color.tab_indicator_text),
-                        context.getResources().getColor(android.R.color.tab_indicator_text));
-            } else if (stepCount < activityMilestoneThree) {
-                dataSet.setColors(context.getResources().getColor(R.color.actifitDarkGreen),
-                        context.getResources().getColor(android.R.color.tab_indicator_text),
-                        context.getResources().getColor(android.R.color.tab_indicator_text));
-            } else {
-                dataSet.setColors(context.getResources().getColor(R.color.actifitDarkGreen));
-            }
-
-            dataSet.setSliceSpace(1f);
-            dataSet.setHighlightEnabled(true);
-            dataSet.setValueTextSize(0f);
-            dataSet.setValueTextColor(ColorTemplate.COLOR_NONE);
-            dataSet.setValueTextColor(R.color.actifitRed);
-
-            if (animate) {
-                btnPieChart.animateXY(2000, 2000);
-            } else {
-                btnPieChart.invalidate();
             }
         });
     }
 
     public void displayActivityChartFitbit(final int stepCount, final boolean animate) {
         ((android.app.Activity) context).runOnUiThread(() -> {
-            fitbitPieChart = ((android.app.Activity) context).findViewById(R.id.step_pie_chart_fitbit);
-            ArrayList<PieEntry> activityArray = new ArrayList();
-            activityArray.add(new PieEntry(stepCount, ""));
+            stepRingFitbit = ((android.app.Activity) context).findViewById(R.id.step_ring_fitbit);
+            android.widget.TextView tvCount = ((android.app.Activity) context).findViewById(R.id.tv_step_count_fitbit);
+            android.widget.TextView tvGoal = ((android.app.Activity) context).findViewById(R.id.tv_step_goal_fitbit);
+            android.widget.TextView tvPct = ((android.app.Activity) context).findViewById(R.id.tv_step_pct_fitbit);
+            if (stepRingFitbit == null) return;
+
+            updateRing(stepRingFitbit, tvCount, tvGoal, tvPct, stepCount, animate);
 
             if (stepCount > 2000) {
-                if (BtnWaves != null && (BtnWaves.getAnimation() == null || BtnWaves.getAnimation().hasStarted())) {
-                    if (scaler != null) BtnWaves.setAnimation(scaler);
+                if (BtnWaves != null && (BtnWaves.getAnimation() == null || !BtnWaves.getAnimation().hasStarted())) {
+                    if (scaler != null) BtnWaves.startAnimation(scaler);
                 }
+            } else {
+                if (BtnWaves != null) BtnWaves.clearAnimation();
             }
-
-            if (stepCount < activityMilestoneOne) {
-                activityArray.add(new PieEntry(activityMilestoneOne - stepCount, ""));
-                activityArray.add(new PieEntry(activityMilestoneOne, ""));
-            } else if (stepCount < activityMilestoneThree) {
+            if (stepCount >= activityMilestoneOne && stepCount < activityMilestoneThree) {
                 if (BtnPostSteemit != null && scaler != null) {
                     if (BtnPostSteemit.getAnimation() == null || BtnPostSteemit.getAnimation().hasStarted()) {
                         BtnPostSteemit.startAnimation(scaler);
                     }
                 }
-                activityArray.add(new PieEntry(activityMilestoneThree - stepCount, ""));
-            }
-
-            PieDataSet dataSet = new PieDataSet(activityArray, "");
-            PieData data = new PieData(dataSet);
-            fitbitPieChart.setData(data);
-            fitbitPieChart.getDescription().setEnabled(false);
-            fitbitPieChart.setCenterText("" + (Math.max(stepCount, 0)));
-            fitbitPieChart.setCenterTextColor(context.getResources().getColor(R.color.actifitRed));
-            fitbitPieChart.setCenterTextSize(20f);
-            fitbitPieChart.setEntryLabelColor(ColorTemplate.COLOR_NONE);
-            fitbitPieChart.setDrawEntryLabels(false);
-            fitbitPieChart.getLegend().setEnabled(false);
-
-            if (stepCount < activityMilestoneOne) {
-                dataSet.setColors(context.getResources().getColor(R.color.actifitRed),
-                        context.getResources().getColor(android.R.color.tab_indicator_text),
-                        context.getResources().getColor(android.R.color.tab_indicator_text));
-            } else if (stepCount < activityMilestoneThree) {
-                dataSet.setColors(context.getResources().getColor(R.color.actifitDarkGreen),
-                        context.getResources().getColor(android.R.color.tab_indicator_text),
-                        context.getResources().getColor(android.R.color.tab_indicator_text));
-            } else {
-                dataSet.setColors(context.getResources().getColor(R.color.actifitDarkGreen));
-            }
-
-            dataSet.setSliceSpace(1f);
-            dataSet.setHighlightEnabled(true);
-            dataSet.setValueTextSize(0f);
-            dataSet.setValueTextColor(ColorTemplate.COLOR_NONE);
-            dataSet.setValueTextColor(R.color.actifitRed);
-
-            if (animate) {
-                fitbitPieChart.animateXY(2000, 2000);
-            } else {
-                fitbitPieChart.invalidate();
+            } else if (stepCount >= activityMilestoneThree) {
+                if (BtnPostSteemit != null) BtnPostSteemit.clearAnimation();
             }
         });
     }
 
     public void displayActivityChartHealthConnect(final int stepCount, final boolean animate) {
         ((android.app.Activity) context).runOnUiThread(() -> {
-            healthConnectPieChart = ((android.app.Activity) context).findViewById(R.id.step_pie_chart_health_connect);
-            ArrayList<PieEntry> activityArray = new ArrayList();
-            activityArray.add(new PieEntry(stepCount, ""));
+            stepRingHc = ((android.app.Activity) context).findViewById(R.id.step_ring_hc);
+            android.widget.TextView tvCount = ((android.app.Activity) context).findViewById(R.id.tv_step_count_hc);
+            android.widget.TextView tvGoal = ((android.app.Activity) context).findViewById(R.id.tv_step_goal_hc);
+            android.widget.TextView tvPct = ((android.app.Activity) context).findViewById(R.id.tv_step_pct_hc);
+            if (stepRingHc == null) return;
+
+            updateRing(stepRingHc, tvCount, tvGoal, tvPct, stepCount, animate);
 
             if (stepCount > 2000) {
                 if (BtnWaves != null && (BtnWaves.getAnimation() == null || !BtnWaves.getAnimation().hasStarted())) {
                     if (scaler != null) BtnWaves.startAnimation(scaler);
                 }
+            } else {
+                if (BtnWaves != null) BtnWaves.clearAnimation();
             }
-
-            if (stepCount < activityMilestoneOne) {
-                activityArray.add(new PieEntry(activityMilestoneOne - stepCount, ""));
-                activityArray.add(new PieEntry(activityMilestoneOne, ""));
-            } else if (stepCount < activityMilestoneThree) {
+            if (stepCount >= activityMilestoneOne && stepCount < activityMilestoneThree) {
                 if (BtnPostSteemit != null && scaler != null) {
                     if (BtnPostSteemit.getAnimation() == null || !BtnPostSteemit.getAnimation().hasStarted()) {
                         BtnPostSteemit.startAnimation(scaler);
                     }
                 }
-                activityArray.add(new PieEntry(activityMilestoneThree - stepCount, ""));
-            }
-
-            PieDataSet dataSet = new PieDataSet(activityArray, "");
-            PieData data = new PieData(dataSet);
-            healthConnectPieChart.setData(data);
-            healthConnectPieChart.getDescription().setEnabled(false);
-            healthConnectPieChart.setCenterText("" + (Math.max(stepCount, 0)));
-            healthConnectPieChart.setCenterTextColor(context.getResources().getColor(R.color.actifitRed));
-            healthConnectPieChart.setCenterTextSize(20f);
-            healthConnectPieChart.setEntryLabelColor(ColorTemplate.COLOR_NONE);
-            healthConnectPieChart.setDrawEntryLabels(false);
-            healthConnectPieChart.getLegend().setEnabled(false);
-
-            if (stepCount < activityMilestoneOne) {
-                dataSet.setColors(context.getResources().getColor(R.color.actifitRed),
-                        context.getResources().getColor(android.R.color.tab_indicator_text),
-                        context.getResources().getColor(android.R.color.tab_indicator_text));
-            } else if (stepCount < activityMilestoneThree) {
-                dataSet.setColors(context.getResources().getColor(R.color.actifitDarkGreen),
-                        context.getResources().getColor(android.R.color.tab_indicator_text),
-                        context.getResources().getColor(android.R.color.tab_indicator_text));
-            } else {
-                dataSet.setColors(context.getResources().getColor(R.color.actifitDarkGreen));
-            }
-
-            dataSet.setSliceSpace(1f);
-            dataSet.setHighlightEnabled(true);
-            dataSet.setValueTextSize(0f);
-            dataSet.setValueTextColor(ColorTemplate.COLOR_NONE);
-
-            if (animate) {
-                healthConnectPieChart.animateXY(2000, 2000);
-            } else {
-                healthConnectPieChart.invalidate();
+            } else if (stepCount >= activityMilestoneThree) {
+                if (BtnPostSteemit != null) BtnPostSteemit.clearAnimation();
             }
         });
     }
@@ -472,20 +391,17 @@ public class ChartManager {
     }
 
     public void hideCharts() {
-        if (btnPieChart == null) btnPieChart = ((android.app.Activity) context).findViewById(R.id.step_pie_chart);
+        View defaultContainer = ((android.app.Activity) context).findViewById(R.id.default_chart_container);
         if (thirdPartyTracking == null) thirdPartyTracking = ((android.app.Activity) context).findViewById(R.id.third_party_active);
         if (healthConnectTracking == null) healthConnectTracking = ((android.app.Activity) context).findViewById(R.id.health_connect_active);
 
-        View pieChartView = btnPieChart;
-        if (pieChartView != null && pieChartView.getParent() instanceof View) {
-            ((View) pieChartView.getParent()).setVisibility(View.GONE);
-        }
-        thirdPartyTracking.setVisibility(View.GONE);
-        healthConnectTracking.setVisibility(View.GONE);
+        if (defaultContainer != null) defaultContainer.setVisibility(View.GONE);
+        if (thirdPartyTracking != null) thirdPartyTracking.setVisibility(View.GONE);
+        if (healthConnectTracking != null) healthConnectTracking.setVisibility(View.GONE);
 
         if (chartSwitcher != null) chartSwitcher.setVisibility(View.INVISIBLE);
         View barCharts = ((android.app.Activity) context).findViewById(R.id.bar_chart_container);
-        barCharts.setVisibility(View.INVISIBLE);
+        if (barCharts != null) barCharts.setVisibility(View.INVISIBLE);
     }
 
     public void slideRight(View view) {

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
@@ -1787,8 +1787,8 @@ public class MainActivity extends BaseActivity {
             dialog.show(getSupportFragmentManager(), "video_upload_fragment");
         });
 
-        // More footer button — opens bottom sheet overflow menu
-        TextView BtnMoreFooter = findViewById(R.id.btn_more_footer);
+        // More footer button — handled by BaseActivity.showMoreMenu()
+        View BtnMoreFooter = findViewById(R.id.btn_more_footer);
         if (BtnMoreFooter != null) {
             BtnMoreFooter.setOnClickListener(v -> showMoreMenu());
         }
@@ -2488,41 +2488,6 @@ public class MainActivity extends BaseActivity {
 
     private void loadSignupLinks(RequestQueue queue) {
         apiManager.loadSignupLinks(queue);
-    }
-
-    private void showMoreMenu() {
-        com.google.android.material.bottomsheet.BottomSheetDialog sheet =
-                new com.google.android.material.bottomsheet.BottomSheetDialog(this);
-        android.view.View sheetView = getLayoutInflater().inflate(R.layout.bottom_sheet_more_menu, null);
-        sheet.setContentView(sheetView);
-
-        sheetView.findViewById(R.id.more_item_history).setOnClickListener(v -> {
-            sheet.dismiss();
-            startActivity(new Intent(this, StepHistoryActivity.class));
-        });
-        sheetView.findViewById(R.id.more_item_videos).setOnClickListener(v -> {
-            sheet.dismiss();
-            VideoUploadFragment vDialog = new VideoUploadFragment(getApplicationContext(),
-                    LoginActivity.accessToken, this, false);
-            vDialog.show(getSupportFragmentManager(), "video_upload_fragment");
-        });
-        sheetView.findViewById(R.id.more_item_socials).setOnClickListener(v -> {
-            sheet.dismiss();
-            startActivity(new Intent(this, SocialActivity.class));
-        });
-        sheetView.findViewById(R.id.more_item_help).setOnClickListener(v -> {
-            sheet.dismiss();
-            androidx.browser.customtabs.CustomTabsIntent.Builder helpBuilder =
-                    new androidx.browser.customtabs.CustomTabsIntent.Builder();
-            helpBuilder.setToolbarColor(getResources().getColor(R.color.actifitRed));
-            helpBuilder.build().launchUrl(this, android.net.Uri.parse("https://actifit.io/faq"));
-        });
-        sheetView.findViewById(R.id.more_item_chat).setOnClickListener(v -> {
-            sheet.dismiss();
-            startActivity(new Intent(this, SocialActivity.class));
-        });
-
-        sheet.show();
     }
 
     private void updateNudgeCard(int stepCount) {

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
@@ -107,7 +107,6 @@ import com.android.volley.toolbox.Volley;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.target.Target;
 import com.github.mikephil.charting.charts.BarChart;
-import com.github.mikephil.charting.charts.PieChart;
 import com.github.mikephil.charting.components.AxisBase;
 import com.github.mikephil.charting.components.Description;
 import com.github.mikephil.charting.components.Legend;
@@ -300,9 +299,7 @@ public class MainActivity extends BaseActivity {
 
     String checkMark = "&#10003;";
 
-    PieChart btnPieChart;
-    PieChart fitbitPieChart;
-    PieChart healthConnectPieChart;
+    View defaultChartContainer;
 
     static boolean isActivityVisible = true;
 
@@ -840,7 +837,7 @@ public class MainActivity extends BaseActivity {
         fullChartButton = findViewById(R.id.daily_chart_btn);
         dayChartButton = findViewById(R.id.hourly_chart_btn);
         chartSwitcher = findViewById(R.id.chart_switcher);
-        btnPieChart = findViewById(R.id.step_pie_chart);
+        defaultChartContainer = findViewById(R.id.default_chart_container);
 
         // allow opening signup link
         signupLink.setMovementMethod(LinkMovementMethod.getInstance());
@@ -1787,9 +1784,45 @@ public class MainActivity extends BaseActivity {
             // show video modal
             VideoUploadFragment dialog = new VideoUploadFragment(getApplicationContext(), LoginActivity.accessToken,
                     this, false);
-            // dialog.getView().setMinimumWidth(400);
             dialog.show(getSupportFragmentManager(), "video_upload_fragment");
         });
+
+        // More footer button — opens overflow menu with hidden items
+        TextView BtnMoreFooter = findViewById(R.id.btn_more_footer);
+        if (BtnMoreFooter != null) {
+            BtnMoreFooter.setOnClickListener(v -> {
+                String[] labels = {"History", "Videos", "Socials", "Help", "Chat"};
+                new androidx.appcompat.app.AlertDialog.Builder(this)
+                        .setTitle("More")
+                        .setItems(labels, (dialog, which) -> {
+                            switch (which) {
+                                case 0:
+                                    startActivity(new Intent(MainActivity.this, StepHistoryActivity.class));
+                                    break;
+                                case 1:
+                                    VideoUploadFragment vDialog = new VideoUploadFragment(getApplicationContext(),
+                                            LoginActivity.accessToken, MainActivity.this, false);
+                                    vDialog.show(getSupportFragmentManager(), "video_upload_fragment");
+                                    break;
+                                case 2:
+                                    startActivity(new Intent(MainActivity.this, SocialActivity.class));
+                                    break;
+                                case 3:
+                                    androidx.browser.customtabs.CustomTabsIntent.Builder helpBuilder =
+                                            new androidx.browser.customtabs.CustomTabsIntent.Builder();
+                                    helpBuilder.setToolbarColor(getResources().getColor(R.color.actifitRed));
+                                    helpBuilder.build().launchUrl(MainActivity.this,
+                                            android.net.Uri.parse("https://actifit.io/faq"));
+                                    break;
+                                case 4:
+                                    BtnVideo.performClick();
+                                    break;
+                            }
+                        })
+                        .setNegativeButton("Cancel", null)
+                        .show();
+            });
+        }
 
         // handle activity to move to post to steemit screen
         BtnPostSteemit.setOnClickListener(arg0 -> {
@@ -2087,7 +2120,7 @@ public class MainActivity extends BaseActivity {
 
                 // Switch back to device sensor tracking
                 hideCharts();
-                ((View) btnPieChart.getParent()).setVisibility(View.VISIBLE);
+                if (defaultChartContainer != null) defaultChartContainer.setVisibility(View.VISIBLE);
                 chartSwitcher.setVisibility(View.VISIBLE);
                 findViewById(R.id.bar_chart_container).setVisibility(View.VISIBLE);
 
@@ -2426,6 +2459,7 @@ public class MainActivity extends BaseActivity {
 
     private void displayActivityChart(final int stepCount, final boolean animate) {
         chartManager.displayActivityChart(stepCount, animate);
+        updateNudgeCard(stepCount);
     }
 
     private class DisplayDayChartDataAsyncTask extends AsyncTask<Boolean, Void, ArrayList<ActivitySlot>> {
@@ -2477,8 +2511,40 @@ public class MainActivity extends BaseActivity {
         apiManager.displayPendingRewards(queue);
     }
 
+    private void displayEstimatedReward() {
+        RequestQueue queue = Volley.newRequestQueue(this);
+        TextView tvEstimatedAfit = findViewById(R.id.tv_estimated_afit);
+        apiManager.displayEstimatedReward(queue, tvEstimatedAfit);
+    }
+
     private void loadSignupLinks(RequestQueue queue) {
         apiManager.loadSignupLinks(queue);
+    }
+
+    private void updateNudgeCard(int stepCount) {
+        View nudgeCard = findViewById(R.id.nudge_card);
+        TextView tvMsg = findViewById(R.id.tv_nudge_message);
+        TextView tvIcon = findViewById(R.id.tv_nudge_icon);
+        TextView tvDismiss = findViewById(R.id.tv_nudge_dismiss);
+        if (nudgeCard == null || tvMsg == null) return;
+
+        String msg;
+        String icon;
+        if (stepCount < activityMilestoneOne) {
+            int stepsLeft = activityMilestoneOne - stepCount;
+            msg = "Keep going! You're " + stepsLeft + " steps from your first reward";
+            icon = "";
+        } else if (stepCount < activityMilestoneThree) {
+            msg = "You've hit " + activityMilestoneOne + " steps — claim your reward now!";
+            icon = "";
+        } else {
+            msg = "Great day! Share your achievement";
+            icon = "";
+        }
+        tvMsg.setText(msg);
+        if (tvIcon != null) tvIcon.setText(icon);
+        nudgeCard.setVisibility(View.VISIBLE);
+        if (tvDismiss != null) tvDismiss.setOnClickListener(v -> nudgeCard.setVisibility(View.GONE));
     }
 
     private void claimFreeSignupLinks(RequestQueue queue) {
@@ -3028,6 +3094,8 @@ public class MainActivity extends BaseActivity {
 
                 displayUserBalance();
 
+                displayEstimatedReward();
+
                 displayVotingStatus();
 
                 displayUserGadgets();
@@ -3337,6 +3405,8 @@ public class MainActivity extends BaseActivity {
 
             displayUserBalance();
 
+            displayEstimatedReward();
+
             displayVotingStatus();
 
             displayPendingRewards();
@@ -3351,7 +3421,7 @@ public class MainActivity extends BaseActivity {
 
             if (dataTrackingSystem.equals(getString(R.string.device_tracking_ntt))) {
                 hideCharts();
-                ((View) btnPieChart.getParent()).setVisibility(View.VISIBLE);
+                if (defaultChartContainer != null) defaultChartContainer.setVisibility(View.VISIBLE);
                 chartSwitcher.setVisibility(View.VISIBLE);
                 findViewById(R.id.bar_chart_container).setVisibility(View.VISIBLE);
                 displayActivityChart(stepCount, true);
@@ -3367,7 +3437,7 @@ public class MainActivity extends BaseActivity {
             } else {
                 // Default fallback
                 hideCharts();
-                ((View) btnPieChart.getParent()).setVisibility(View.VISIBLE);
+                if (defaultChartContainer != null) defaultChartContainer.setVisibility(View.VISIBLE);
                 displayActivityChart(stepCount, true);
             }
 

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
@@ -952,7 +952,7 @@ public class MainActivity extends BaseActivity {
         thirdPartyTracking = findViewById(R.id.third_party_active);
         healthConnectTracking = findViewById(R.id.health_connect_active);
 
-        TextView BtnLeaderboard = findViewById(R.id.btn_view_leaderboard);
+        View BtnLeaderboard = findViewById(R.id.btn_view_leaderboard);
         TextView BtnWallet = findViewById(R.id.btn_view_wallet);
         TextView BtnViewNotifications = findViewById(R.id.btn_view_notifications);
         LinearLayout BtnWalletAltContainer = findViewById(R.id.wallet_alt_container);
@@ -964,8 +964,8 @@ public class MainActivity extends BaseActivity {
         TextView BtnShareAchievement = findViewById(R.id.btn_share_achievement);
         TextView BtnShareAchievementFitbit = findViewById(R.id.btn_share_achievement_fitbit);
         TextView BtnShareAchievementHC = findViewById(R.id.btn_share_achievement_hc);
-        TextView BtnMarket = findViewById(R.id.btn_view_market);
-        TextView BtnPosts = findViewById(R.id.btn_view_social);
+        View BtnMarket = findViewById(R.id.btn_view_market);
+        View BtnPosts = findViewById(R.id.btn_view_social);
         BtnWaves = findViewById(R.id.btn_waves);
         TextView BtnSwitchSettings = findViewById(R.id.switchSettings);
 
@@ -2421,10 +2421,14 @@ public class MainActivity extends BaseActivity {
 
     private void displayActivityChartFitbit(final int stepCount, final boolean animate) {
         chartManager.displayActivityChartFitbit(stepCount, animate);
+        updateNudgeCard(stepCount);
+        if (animate) checkMilestoneCelebration(stepCount);
     }
 
     private void displayActivityChartHealthConnect(final int stepCount, final boolean animate) {
         chartManager.displayActivityChartHealthConnect(stepCount, animate);
+        updateNudgeCard(stepCount);
+        if (animate) checkMilestoneCelebration(stepCount);
     }
 
     private void displayActivityChart(final int stepCount, final boolean animate) {
@@ -2803,7 +2807,7 @@ public class MainActivity extends BaseActivity {
         View btnBrowseMarket = findViewById(R.id.btn_browse_market_gadgets);
         if (btnBrowseMarket != null) {
             btnBrowseMarket.setOnClickListener(v -> {
-                TextView btnMarket = findViewById(R.id.btn_view_market);
+                View btnMarket = findViewById(R.id.btn_view_market);
                 if (btnMarket != null) btnMarket.performClick();
             });
         }

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
@@ -1787,41 +1787,10 @@ public class MainActivity extends BaseActivity {
             dialog.show(getSupportFragmentManager(), "video_upload_fragment");
         });
 
-        // More footer button — opens overflow menu with hidden items
+        // More footer button — opens bottom sheet overflow menu
         TextView BtnMoreFooter = findViewById(R.id.btn_more_footer);
         if (BtnMoreFooter != null) {
-            BtnMoreFooter.setOnClickListener(v -> {
-                String[] labels = {"History", "Videos", "Socials", "Help", "Chat"};
-                new androidx.appcompat.app.AlertDialog.Builder(this)
-                        .setTitle("More")
-                        .setItems(labels, (dialog, which) -> {
-                            switch (which) {
-                                case 0:
-                                    startActivity(new Intent(MainActivity.this, StepHistoryActivity.class));
-                                    break;
-                                case 1:
-                                    VideoUploadFragment vDialog = new VideoUploadFragment(getApplicationContext(),
-                                            LoginActivity.accessToken, MainActivity.this, false);
-                                    vDialog.show(getSupportFragmentManager(), "video_upload_fragment");
-                                    break;
-                                case 2:
-                                    startActivity(new Intent(MainActivity.this, SocialActivity.class));
-                                    break;
-                                case 3:
-                                    androidx.browser.customtabs.CustomTabsIntent.Builder helpBuilder =
-                                            new androidx.browser.customtabs.CustomTabsIntent.Builder();
-                                    helpBuilder.setToolbarColor(getResources().getColor(R.color.actifitRed));
-                                    helpBuilder.build().launchUrl(MainActivity.this,
-                                            android.net.Uri.parse("https://actifit.io/faq"));
-                                    break;
-                                case 4:
-                                    BtnVideo.performClick();
-                                    break;
-                            }
-                        })
-                        .setNegativeButton("Cancel", null)
-                        .show();
-            });
+            BtnMoreFooter.setOnClickListener(v -> showMoreMenu());
         }
 
         // handle activity to move to post to steemit screen
@@ -2519,6 +2488,41 @@ public class MainActivity extends BaseActivity {
 
     private void loadSignupLinks(RequestQueue queue) {
         apiManager.loadSignupLinks(queue);
+    }
+
+    private void showMoreMenu() {
+        com.google.android.material.bottomsheet.BottomSheetDialog sheet =
+                new com.google.android.material.bottomsheet.BottomSheetDialog(this);
+        android.view.View sheetView = getLayoutInflater().inflate(R.layout.bottom_sheet_more_menu, null);
+        sheet.setContentView(sheetView);
+
+        sheetView.findViewById(R.id.more_item_history).setOnClickListener(v -> {
+            sheet.dismiss();
+            startActivity(new Intent(this, StepHistoryActivity.class));
+        });
+        sheetView.findViewById(R.id.more_item_videos).setOnClickListener(v -> {
+            sheet.dismiss();
+            VideoUploadFragment vDialog = new VideoUploadFragment(getApplicationContext(),
+                    LoginActivity.accessToken, this, false);
+            vDialog.show(getSupportFragmentManager(), "video_upload_fragment");
+        });
+        sheetView.findViewById(R.id.more_item_socials).setOnClickListener(v -> {
+            sheet.dismiss();
+            startActivity(new Intent(this, SocialActivity.class));
+        });
+        sheetView.findViewById(R.id.more_item_help).setOnClickListener(v -> {
+            sheet.dismiss();
+            androidx.browser.customtabs.CustomTabsIntent.Builder helpBuilder =
+                    new androidx.browser.customtabs.CustomTabsIntent.Builder();
+            helpBuilder.setToolbarColor(getResources().getColor(R.color.actifitRed));
+            helpBuilder.build().launchUrl(this, android.net.Uri.parse("https://actifit.io/faq"));
+        });
+        sheetView.findViewById(R.id.more_item_chat).setOnClickListener(v -> {
+            sheet.dismiss();
+            startActivity(new Intent(this, SocialActivity.class));
+        });
+
+        sheet.show();
     }
 
     private void updateNudgeCard(int stepCount) {

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
@@ -331,6 +331,7 @@ public class MainActivity extends BaseActivity {
     final int activityMilestoneOne = 5000;
     final int activityMilestoneTwo = 7000;
     final int activityMilestoneThree = 10000;
+    private int lastCelebrationMilestone = 0;
 
     private RewardedAd rewardedAd;
     private Button dailyRewardButton;
@@ -2429,6 +2430,7 @@ public class MainActivity extends BaseActivity {
     private void displayActivityChart(final int stepCount, final boolean animate) {
         chartManager.displayActivityChart(stepCount, animate);
         updateNudgeCard(stepCount);
+        if (animate) checkMilestoneCelebration(stepCount);
     }
 
     private class DisplayDayChartDataAsyncTask extends AsyncTask<Boolean, Void, ArrayList<ActivitySlot>> {
@@ -2573,6 +2575,182 @@ public class MainActivity extends BaseActivity {
         }
     }
 
+    private void checkMilestoneCelebration(int stepCount) {
+        int milestone = 0;
+        String message = null;
+        if (stepCount >= activityMilestoneThree && lastCelebrationMilestone < activityMilestoneThree) {
+            milestone = activityMilestoneThree;
+            message = "10,000 steps! Daily goal complete!";
+        } else if (stepCount >= activityMilestoneTwo && lastCelebrationMilestone < activityMilestoneTwo) {
+            milestone = activityMilestoneTwo;
+            message = "7,000 steps! Almost there!";
+        } else if (stepCount >= activityMilestoneOne && lastCelebrationMilestone < activityMilestoneOne) {
+            milestone = activityMilestoneOne;
+            message = "5,000 steps! First reward unlocked!";
+        }
+        if (milestone == 0) return;
+        lastCelebrationMilestone = milestone;
+        final String finalMessage = message;
+        // Pulse the step count text
+        TextView tvCount = findViewById(R.id.tv_step_count);
+        if (tvCount != null) {
+            tvCount.animate().scaleX(1.4f).scaleY(1.4f).setDuration(150)
+                .withEndAction(() -> tvCount.animate().scaleX(1f).scaleY(1f).setDuration(250).start())
+                .start();
+        }
+        Toast.makeText(this, finalMessage, Toast.LENGTH_SHORT).show();
+    }
+
+    private void loadAiInsight() {
+        android.content.SharedPreferences prefs = getSharedPreferences("actifitSets", MODE_PRIVATE);
+        String todayStr = new SimpleDateFormat("yyyyMMdd", Locale.ENGLISH).format(new java.util.Date());
+        String cachedDate = prefs.getString("ai_insight_date", "");
+        String cachedText = prefs.getString("ai_insight_text", "");
+        View aiCard = findViewById(R.id.ai_insight_card);
+        TextView tvInsight = findViewById(R.id.tv_ai_insight);
+        if (aiCard == null || tvInsight == null) return;
+
+        if (todayStr.equals(cachedDate) && !cachedText.isEmpty()) {
+            tvInsight.setText(cachedText);
+            aiCard.setVisibility(View.VISIBLE);
+            return;
+        }
+
+        // Compute inputs for the prompt
+        int todaySteps = mStepsDBHelper != null ? mStepsDBHelper.fetchTodayStepCount() : 0;
+        int streakDays = 0;
+        int totalSteps7d = 0;
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd", Locale.ENGLISH);
+        Calendar todayStepsCal = Calendar.getInstance();
+        int todayStepsVal = mStepsDBHelper != null ? mStepsDBHelper.fetchStepCountByDate(sdf.format(todayStepsCal.getTime())) : -1;
+        int startDaysBack = (todayStepsVal >= 5000) ? 0 : 1;
+        for (int i = startDaysBack; i <= 30; i++) {
+            Calendar c = Calendar.getInstance(); c.add(Calendar.DATE, -i);
+            int s = mStepsDBHelper != null ? mStepsDBHelper.fetchStepCountByDate(sdf.format(c.getTime())) : -1;
+            if (s >= 5000) streakDays++; else break;
+        }
+        for (int i = 0; i < 7; i++) {
+            Calendar c = Calendar.getInstance(); c.add(Calendar.DATE, -i);
+            int s = mStepsDBHelper != null ? mStepsDBHelper.fetchStepCountByDate(sdf.format(c.getTime())) : 0;
+            totalSteps7d += Math.max(s, 0);
+        }
+        int avgSteps7d = totalSteps7d / 7;
+
+        AiService aiService = new AiService();
+        final int finalStreak = streakDays;
+        aiService.generateDashboardInsight(todaySteps, finalStreak, avgSteps7d, new AiService.TextResponseCallback() {
+            @Override
+            public void onSuccess(String insight) {
+                runOnUiThread(() -> {
+                    tvInsight.setText(insight);
+                    aiCard.setVisibility(View.VISIBLE);
+                    prefs.edit()
+                        .putString("ai_insight_date", todayStr)
+                        .putString("ai_insight_text", insight)
+                        .apply();
+                });
+            }
+            @Override
+            public void onFailure(String errorMessage) {
+                Log.e(TAG, "AI insight error: " + errorMessage);
+            }
+        });
+    }
+
+    private void buildMonthHeatmap() {
+        LinearLayout heatmapGrid = findViewById(R.id.heatmap_grid);
+        if (heatmapGrid == null || mStepsDBHelper == null) return;
+        heatmapGrid.removeAllViews();
+
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd", Locale.ENGLISH);
+        Calendar today = Calendar.getInstance();
+        int year = today.get(Calendar.YEAR);
+        int month = today.get(Calendar.MONTH);
+        int todayDay = today.get(Calendar.DAY_OF_MONTH);
+
+        Calendar monthStart = Calendar.getInstance();
+        monthStart.set(year, month, 1);
+        int daysInMonth = monthStart.getActualMaximum(Calendar.DAY_OF_MONTH);
+        int firstDow = monthStart.get(Calendar.DAY_OF_WEEK);
+        int leadingBlanks = (firstDow == Calendar.SUNDAY) ? 6 : firstDow - Calendar.MONDAY;
+
+        // Update title with month name
+        TextView tvTitle = findViewById(R.id.tv_heatmap_title);
+        if (tvTitle != null) {
+            tvTitle.setText(new SimpleDateFormat("MMMM yyyy", Locale.ENGLISH).format(today.getTime()));
+        }
+
+        int[] stepsByDay = new int[daysInMonth + 1];
+        for (int d = 1; d <= todayDay; d++) {
+            Calendar c = Calendar.getInstance();
+            c.set(year, month, d);
+            stepsByDay[d] = mStepsDBHelper.fetchStepCountByDate(sdf.format(c.getTime()));
+        }
+
+        float density = getResources().getDisplayMetrics().density;
+        int cellH = (int) (14 * density);
+        int gapPx = (int) (3 * density);
+
+        // Day header row
+        String[] headers = {"M", "T", "W", "T", "F", "S", "S"};
+        LinearLayout headerRow = new LinearLayout(this);
+        headerRow.setOrientation(LinearLayout.HORIZONTAL);
+        LinearLayout.LayoutParams headerLp = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
+        headerLp.setMargins(0, 0, 0, gapPx);
+        headerRow.setLayoutParams(headerLp);
+        for (String h : headers) {
+            TextView tv = new TextView(this);
+            LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f);
+            lp.setMargins(0, 0, gapPx, 0);
+            tv.setLayoutParams(lp);
+            tv.setText(h);
+            tv.setTextSize(9);
+            tv.setGravity(Gravity.CENTER);
+            tv.setTextColor(ContextCompat.getColor(this, R.color.md_theme_textSecondary));
+            headerRow.addView(tv);
+        }
+        heatmapGrid.addView(headerRow);
+
+        int totalCells = leadingBlanks + daysInMonth;
+        int numRows = (int) Math.ceil(totalCells / 7.0);
+        for (int row = 0; row < numRows; row++) {
+            LinearLayout rowLayout = new LinearLayout(this);
+            rowLayout.setOrientation(LinearLayout.HORIZONTAL);
+            LinearLayout.LayoutParams rowLp = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, cellH);
+            rowLp.setMargins(0, 0, 0, gapPx);
+            rowLayout.setLayoutParams(rowLp);
+
+            for (int col = 0; col < 7; col++) {
+                int cellIdx = row * 7 + col;
+                int dayNum = cellIdx - leadingBlanks + 1;
+                View cell = new View(this);
+                LinearLayout.LayoutParams cellLp = new LinearLayout.LayoutParams(0, cellH, 1f);
+                cellLp.setMargins(0, 0, gapPx, 0);
+                cell.setLayoutParams(cellLp);
+
+                android.graphics.drawable.GradientDrawable gd = new android.graphics.drawable.GradientDrawable();
+                gd.setShape(android.graphics.drawable.GradientDrawable.OVAL);
+
+                if (dayNum < 1 || dayNum > daysInMonth) {
+                    cell.setVisibility(View.INVISIBLE);
+                } else if (dayNum > todayDay) {
+                    gd.setColor(Color.TRANSPARENT);
+                    gd.setStroke((int) density, 0xFFE0E0E0);
+                    cell.setBackground(gd);
+                } else {
+                    int steps = stepsByDay[dayNum];
+                    if (steps <= 0) gd.setColor(0xFFE8E8E8);
+                    else if (steps < 5000) gd.setColor(0xFFFFCDD2);
+                    else if (steps < 7000) gd.setColor(0xFFEF9A9A);
+                    else gd.setColor(0xFFFF112D);
+                    cell.setBackground(gd);
+                }
+                rowLayout.addView(cell);
+            }
+            heatmapGrid.addView(rowLayout);
+        }
+    }
+
     private void claimFreeSignupLinks(RequestQueue queue) {
         String claimLink = Utils.apiUrl(this) + getString(R.string.claim_free_signup_links) + username;
         // Request the user's active gadgets list
@@ -2619,7 +2797,16 @@ public class MainActivity extends BaseActivity {
     private void displayUserGadgets() {
         RequestQueue queue = Volley.newRequestQueue(this);
         LinearLayout userGadgets = findViewById(R.id.user_gadgets);
+        LinearLayout ctaContainer = findViewById(R.id.missing_active_gadgets_container);
+        if (ctaContainer != null) ctaContainer.setVisibility(View.VISIBLE);
         TextView noActiveGadgets = findViewById(R.id.missing_active_gadgets);
+        View btnBrowseMarket = findViewById(R.id.btn_browse_market_gadgets);
+        if (btnBrowseMarket != null) {
+            btnBrowseMarket.setOnClickListener(v -> {
+                TextView btnMarket = findViewById(R.id.btn_view_market);
+                if (btnMarket != null) btnMarket.performClick();
+            });
+        }
         apiManager.displayUserGadgets(queue, userGadgets, noActiveGadgets);
     }
 
@@ -2647,11 +2834,9 @@ public class MainActivity extends BaseActivity {
 
             userGadgets.addView(horizontalScrollView);
 
-            // hide no gadgets display as we do have active gadgets
-            // LinearLayout noActiveGadgets =
-            // findViewById(R.id.missing_active_gadgets_container);
-            TextView noActiveGadgets = findViewById(R.id.missing_active_gadgets);
-            noActiveGadgets.setVisibility(GONE);
+            // hide no-gadgets CTA as we do have active gadgets
+            LinearLayout ctaContainer2 = findViewById(R.id.missing_active_gadgets_container);
+            if (ctaContainer2 != null) ctaContainer2.setVisibility(GONE);
             for (int i = 0; i < activeProducts.length(); i++) {
                 try {
                     // find matching image
@@ -3124,6 +3309,10 @@ public class MainActivity extends BaseActivity {
 
                 updateStreakStrip();
 
+                loadAiInsight();
+
+                buildMonthHeatmap();
+
                 displayVotingStatus();
 
                 displayUserGadgets();
@@ -3436,6 +3625,10 @@ public class MainActivity extends BaseActivity {
             displayEstimatedReward();
 
             updateStreakStrip();
+
+            loadAiInsight();
+
+            buildMonthHeatmap();
 
             displayVotingStatus();
 

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
@@ -2516,6 +2516,63 @@ public class MainActivity extends BaseActivity {
         if (tvDismiss != null) tvDismiss.setOnClickListener(v -> nudgeCard.setVisibility(View.GONE));
     }
 
+    private void updateStreakStrip() {
+        int[] dayViewIds = {
+            R.id.streak_day_0, R.id.streak_day_1, R.id.streak_day_2,
+            R.id.streak_day_3, R.id.streak_day_4, R.id.streak_day_5, R.id.streak_day_6
+        };
+        int[] labelViewIds = {
+            R.id.streak_label_0, R.id.streak_label_1, R.id.streak_label_2,
+            R.id.streak_label_3, R.id.streak_label_4, R.id.streak_label_5, R.id.streak_label_6
+        };
+        String[] dayAbbr = {"Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"};
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd", Locale.ENGLISH);
+
+        // Fill 7-day window: index 0 = 6 days ago, index 6 = today
+        for (int i = 0; i < 7; i++) {
+            Calendar dayCal = Calendar.getInstance();
+            dayCal.add(Calendar.DATE, -(6 - i));
+            String dateStr = sdf.format(dayCal.getTime());
+            int steps = mStepsDBHelper != null ? mStepsDBHelper.fetchStepCountByDate(dateStr) : -1;
+            boolean active = steps >= 5000;
+
+            View dayView = findViewById(dayViewIds[i]);
+            if (dayView != null) {
+                dayView.setBackground(ContextCompat.getDrawable(this,
+                    active ? R.drawable.streak_day_active : R.drawable.streak_day_inactive));
+            }
+            TextView labelView = findViewById(labelViewIds[i]);
+            if (labelView != null) {
+                labelView.setText(dayAbbr[dayCal.get(Calendar.DAY_OF_WEEK) - 1]);
+            }
+        }
+
+        // Compute streak: consecutive days ending at today (skip today if inactive — day in progress)
+        Calendar todayCal = Calendar.getInstance();
+        int todaySteps = mStepsDBHelper != null ? mStepsDBHelper.fetchStepCountByDate(sdf.format(todayCal.getTime())) : -1;
+        int startDaysBack = (todaySteps >= 5000) ? 0 : 1;
+        int streak = 0;
+        for (int daysBack = startDaysBack; daysBack <= 30; daysBack++) {
+            Calendar dayCal = Calendar.getInstance();
+            dayCal.add(Calendar.DATE, -daysBack);
+            int steps = mStepsDBHelper != null ? mStepsDBHelper.fetchStepCountByDate(sdf.format(dayCal.getTime())) : -1;
+            if (steps >= 5000) {
+                streak++;
+            } else {
+                break;
+            }
+        }
+
+        TextView tvStreakCount = findViewById(R.id.tv_streak_count);
+        if (tvStreakCount != null) {
+            if (streak == 0) {
+                tvStreakCount.setText("No streak yet");
+            } else {
+                tvStreakCount.setText(streak + (streak == 1 ? " day streak" : " day streak"));
+            }
+        }
+    }
+
     private void claimFreeSignupLinks(RequestQueue queue) {
         String claimLink = Utils.apiUrl(this) + getString(R.string.claim_free_signup_links) + username;
         // Request the user's active gadgets list
@@ -3065,6 +3122,8 @@ public class MainActivity extends BaseActivity {
 
                 displayEstimatedReward();
 
+                updateStreakStrip();
+
                 displayVotingStatus();
 
                 displayUserGadgets();
@@ -3375,6 +3434,8 @@ public class MainActivity extends BaseActivity {
             displayUserBalance();
 
             displayEstimatedReward();
+
+            updateStreakStrip();
 
             displayVotingStatus();
 

--- a/app/src/main/res/drawable/drag_handle_bg.xml
+++ b/app/src/main/res/drawable/drag_handle_bg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#CCCCCC" />
+    <corners android:radius="2dp" />
+</shape>

--- a/app/src/main/res/drawable/news_card_bg.xml
+++ b/app/src/main/res/drawable/news_card_bg.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#1A1A1A" />
+    <corners android:radius="12dp" />
+</shape>

--- a/app/src/main/res/drawable/news_gradient_overlay.xml
+++ b/app/src/main/res/drawable/news_gradient_overlay.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <gradient
+        android:startColor="#00000000"
+        android:endColor="#88000000"
+        android:angle="270" />
+</shape>

--- a/app/src/main/res/drawable/streak_day_active.xml
+++ b/app/src/main/res/drawable/streak_day_active.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@color/actifitRed" />
+</shape>

--- a/app/src/main/res/drawable/streak_day_inactive.xml
+++ b/app/src/main/res/drawable/streak_day_inactive.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@color/md_theme_background" />
+    <stroke android:width="1.5dp" android:color="@color/md_theme_separator" />
+</shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -833,34 +833,34 @@
                         android:text="@string/fa_exclamation_circle_solid"
                         android:fontFamily="@font/font_awesome_6_solid" />
 
-                <ImageView
-                    android:id="@+id/hive_logo"
-                    android:contentDescription="HIVE icon"
-                    android:src="@drawable/hive"
-                    android:layout_height="25dp"
-                    android:layout_width="25dp" />
+                    <ImageView
+                        android:id="@+id/hive_logo"
+                        android:contentDescription="HIVE icon"
+                        android:src="@drawable/hive"
+                        android:layout_height="25dp"
+                        android:layout_width="25dp" />
 
-                <ImageView
-                    android:id="@+id/steem_logo"
-                    android:importantForAccessibility="no"
-                    android:src="@drawable/steem"
-                    android:layout_height="25dp"
-                    android:layout_width="0dp"
-                    android:visibility="invisible" />
+                    <ImageView
+                        android:id="@+id/steem_logo"
+                        android:importantForAccessibility="no"
+                        android:src="@drawable/steem"
+                        android:layout_height="25dp"
+                        android:layout_width="0dp"
+                        android:visibility="invisible" />
 
-                <ImageView
-                    android:id="@+id/blurt_logo"
-                    android:contentDescription="BLURT icon"
-                    android:src="@drawable/blurt"
-                    android:layout_height="25dp"
-                    android:layout_width="25dp" />
+                    <ImageView
+                        android:id="@+id/blurt_logo"
+                        android:contentDescription="BLURT icon"
+                        android:src="@drawable/blurt"
+                        android:layout_height="25dp"
+                        android:layout_width="25dp" />
 
-                <ImageView
-                    android:id="@+id/sports_logo"
-                    android:contentDescription="SPORTS icon"
-                    android:src="@drawable/sports"
-                    android:layout_width="25dp"
-                    android:layout_height="25dp" />
+                    <ImageView
+                        android:id="@+id/sports_logo"
+                        android:contentDescription="SPORTS icon"
+                        android:src="@drawable/sports"
+                        android:layout_width="25dp"
+                        android:layout_height="25dp" />
                 </LinearLayout>
             </LinearLayout>
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -214,31 +214,41 @@
             android:padding="@dimen/spacing_md">
 
             <!-- News Carousel -->
-            <androidx.constraintlayout.widget.ConstraintLayout
+            <com.google.android.material.card.MaterialCardView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/spacing_md"
-                android:background="@drawable/slider_background">
+                app:cardCornerRadius="12dp"
+                app:cardElevation="4dp"
+                app:strokeWidth="0dp">
 
-                <androidx.viewpager.widget.ViewPager
-                    android:id="@+id/news_pager"
-                    android:layout_width="0dp"
-                    android:layout_height="130dp"
-                    android:importantForAccessibility="no"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent" />
-
-                <com.google.android.material.tabs.TabLayout
-                    android:id="@+id/news_tablayout"
+                <FrameLayout
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:importantForAccessibility="no"
-                    app:tabGravity="center"
-                    app:tabBackground="@drawable/indicator_selector"
-                    app:tabIndicatorHeight="0dp"
-                    app:layout_constraintBottom_toBottomOf="@+id/news_pager" />
-            </androidx.constraintlayout.widget.ConstraintLayout>
+                    android:layout_height="180dp">
+
+                    <androidx.viewpager.widget.ViewPager
+                        android:id="@+id/news_pager"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:importantForAccessibility="no" />
+
+                    <View
+                        android:layout_width="match_parent"
+                        android:layout_height="56dp"
+                        android:layout_gravity="bottom"
+                        android:background="@drawable/news_gradient_overlay" />
+
+                    <com.google.android.material.tabs.TabLayout
+                        android:id="@+id/news_tablayout"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="bottom"
+                        android:importantForAccessibility="no"
+                        app:tabGravity="center"
+                        app:tabBackground="@drawable/indicator_selector"
+                        app:tabIndicatorHeight="0dp" />
+                </FrameLayout>
+            </com.google.android.material.card.MaterialCardView>
 
             <!-- Hidden image view for compatibility -->
             <ImageView
@@ -1006,56 +1016,43 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
                 android:paddingStart="@dimen/spacing_sm"
-                android:paddingBottom="@dimen/spacing_sm">
+                android:paddingEnd="@dimen/spacing_sm"
+                android:paddingBottom="@dimen/spacing_xs">
 
-                <!-- Estimated AFIT reward row (P1-5) -->
+                <!-- Row 1: label + compact token logos -->
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal"
                     android:gravity="center_vertical"
-                    android:paddingBottom="@dimen/spacing_xs">
+                    android:paddingBottom="2dp">
 
                     <ImageView
                         android:id="@+id/afit_logo"
                         android:contentDescription="AFIT icon"
                         android:src="@drawable/actifit_logo"
-                        android:layout_height="20dp"
-                        android:layout_width="20dp" />
+                        android:layout_height="16dp"
+                        android:layout_width="16dp" />
 
                     <TextView
                         android:id="@+id/tv_reward_label"
-                        android:layout_width="wrap_content"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
+                        android:layout_weight="1"
                         android:paddingStart="@dimen/spacing_xs"
-                        android:text="Est. Reward:"
-                        android:textSize="13sp"
+                        android:text="Estimated Reward"
+                        android:textSize="12sp"
+                        android:textColor="@color/md_theme_secondary"
                         tools:ignore="HardcodedText" />
 
-                    <TextView
-                        android:id="@+id/tv_estimated_afit"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:paddingStart="@dimen/spacing_xs"
-                        android:textSize="13sp"
-                        android:textStyle="bold"
-                        android:textColor="@color/actifitRed"
-                        android:text="..." />
-                </LinearLayout>
-
-                <!-- Token logos row (blockchain breakdown) -->
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    android:gravity="center_vertical">
-
+                    <!-- token_notice kept for Java compat, hidden visually -->
                     <TextView
                         android:id="@+id/token_notice"
-                        android:layout_width="25dp"
-                        android:layout_height="25dp"
+                        android:layout_width="0dp"
+                        android:layout_height="0dp"
+                        android:visibility="gone"
                         android:textColor="@color/md_theme_primary"
-                        android:textSize="20sp"
+                        android:textSize="0sp"
                         android:text="@string/fa_exclamation_circle_solid"
                         android:fontFamily="@font/font_awesome_6_solid" />
 
@@ -1063,14 +1060,15 @@
                         android:id="@+id/hive_logo"
                         android:contentDescription="HIVE icon"
                         android:src="@drawable/hive"
-                        android:layout_height="25dp"
-                        android:layout_width="25dp" />
+                        android:layout_height="18dp"
+                        android:layout_width="18dp"
+                        android:layout_marginStart="4dp" />
 
                     <ImageView
                         android:id="@+id/steem_logo"
                         android:importantForAccessibility="no"
                         android:src="@drawable/steem"
-                        android:layout_height="25dp"
+                        android:layout_height="18dp"
                         android:layout_width="0dp"
                         android:visibility="invisible" />
 
@@ -1078,16 +1076,28 @@
                         android:id="@+id/blurt_logo"
                         android:contentDescription="BLURT icon"
                         android:src="@drawable/blurt"
-                        android:layout_height="25dp"
-                        android:layout_width="25dp" />
+                        android:layout_height="18dp"
+                        android:layout_width="18dp"
+                        android:layout_marginStart="4dp" />
 
                     <ImageView
                         android:id="@+id/sports_logo"
                         android:contentDescription="SPORTS icon"
                         android:src="@drawable/sports"
-                        android:layout_width="25dp"
-                        android:layout_height="25dp" />
+                        android:layout_width="18dp"
+                        android:layout_height="18dp"
+                        android:layout_marginStart="4dp" />
                 </LinearLayout>
+
+                <!-- Row 2: hero AFIT amount -->
+                <TextView
+                    android:id="@+id/tv_estimated_afit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textSize="22sp"
+                    android:textStyle="bold"
+                    android:textColor="@color/actifitRed"
+                    android:text="..." />
             </LinearLayout>
 
             <!-- User Gadgets -->
@@ -1096,7 +1106,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"
-                android:paddingBottom="@dimen/spacing_sm"
                 android:minHeight="40dp"
                 android:weightSum="1.0">
 
@@ -1104,36 +1113,22 @@
                     android:id="@+id/missing_active_gadgets_container"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:padding="@dimen/spacing_sm">
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:paddingStart="@dimen/spacing_sm"
+                    android:paddingEnd="@dimen/spacing_sm"
+                    android:paddingTop="@dimen/spacing_xs"
+                    android:paddingBottom="@dimen/spacing_sm">
 
-                    <LinearLayout
-                        android:layout_width="match_parent"
+                    <TextView
+                        android:id="@+id/missing_active_gadgets"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:gravity="center_vertical">
-
-                        <TextView
-                            android:layout_width="28dp"
-                            android:layout_height="28dp"
-                            android:fontFamily="@font/font_awesome_6_solid"
-                            android:textColor="@color/md_theme_primary"
-                            android:gravity="center"
-                            android:text="\uf135"
-                            android:textSize="18sp"
-                            tools:ignore="HardcodedText" />
-
-                        <TextView
-                            android:id="@+id/missing_active_gadgets"
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1"
-                            android:paddingStart="@dimen/spacing_sm"
-                            android:textSize="13sp"
-                            android:textStyle="bold"
-                            android:text="Activate a Gadget \u2014 Boost earnings up to 2\u00d7"
-                            tools:ignore="HardcodedText" />
-                    </LinearLayout>
+                        android:layout_weight="1"
+                        android:textSize="12sp"
+                        android:textColor="@color/md_theme_secondary"
+                        android:text="No active gadgets"
+                        tools:ignore="HardcodedText" />
 
                     <LinearLayout
                         android:id="@+id/btn_browse_market_gadgets"
@@ -1141,9 +1136,10 @@
                         android:layout_height="wrap_content"
                         android:orientation="horizontal"
                         android:gravity="center_vertical"
-                        android:paddingTop="@dimen/spacing_xs"
-                        android:paddingBottom="@dimen/spacing_xs"
-                        android:paddingEnd="@dimen/spacing_sm"
+                        android:paddingStart="@dimen/spacing_xs"
+                        android:paddingEnd="@dimen/spacing_xs"
+                        android:paddingTop="4dp"
+                        android:paddingBottom="4dp"
                         android:background="?attr/selectableItemBackground"
                         android:clickable="true"
                         android:focusable="true">
@@ -1153,26 +1149,26 @@
                             android:layout_height="wrap_content"
                             android:fontFamily="@font/font_awesome_6_solid"
                             android:textColor="@color/actifitRed"
-                            android:textSize="13sp"
+                            android:textSize="11sp"
                             android:text="&#xf54e;"
                             tools:ignore="HardcodedText" />
 
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:paddingStart="6dp"
+                            android:paddingStart="4dp"
                             android:textColor="@color/actifitRed"
-                            android:textSize="13sp"
-                            android:text="Open in Market"
+                            android:textSize="12sp"
+                            android:text="Market"
                             tools:ignore="HardcodedText" />
 
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:paddingStart="4dp"
+                            android:paddingStart="3dp"
                             android:fontFamily="@font/font_awesome_6_solid"
                             android:textColor="@color/actifitRed"
-                            android:textSize="11sp"
+                            android:textSize="10sp"
                             android:text="&#xf054;"
                             tools:ignore="HardcodedText" />
                     </LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -312,11 +312,55 @@
                             android:layout_height="match_parent"
                             android:visibility="gone">
 
-                            <com.github.mikephil.charting.charts.PieChart
+                            <FrameLayout
                                 android:id="@+id/step_pie_chart_health_connect"
                                 android:layout_width="match_parent"
-                                android:layout_height="match_parent"
-                                android:gravity="center" />
+                                android:layout_height="match_parent">
+
+                                <com.google.android.material.progressindicator.CircularProgressIndicator
+                                    android:id="@+id/step_ring_hc"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_gravity="center"
+                                    android:progress="0"
+                                    android:max="100"
+                                    app:indicatorSize="160dp"
+                                    app:trackThickness="12dp"
+                                    app:indicatorColor="@color/actifitRed"
+                                    app:trackColor="#E0E0E0"
+                                    app:trackCornerRadius="6dp" />
+
+                                <LinearLayout
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_gravity="center"
+                                    android:orientation="vertical"
+                                    android:gravity="center">
+
+                                    <TextView
+                                        android:id="@+id/tv_step_count_hc"
+                                        android:layout_width="wrap_content"
+                                        android:layout_height="wrap_content"
+                                        android:textColor="@color/actifitRed"
+                                        android:textSize="28sp"
+                                        android:textStyle="bold"
+                                        android:text="0" />
+
+                                    <TextView
+                                        android:id="@+id/tv_step_goal_hc"
+                                        android:layout_width="wrap_content"
+                                        android:layout_height="wrap_content"
+                                        android:textSize="11sp"
+                                        android:text="/ 10,000 steps" />
+
+                                    <TextView
+                                        android:id="@+id/tv_step_pct_hc"
+                                        android:layout_width="wrap_content"
+                                        android:layout_height="wrap_content"
+                                        android:textSize="10sp"
+                                        android:text="0% to goal" />
+                                </LinearLayout>
+                            </FrameLayout>
 
                             <ImageView
                                 android:id="@+id/health_connect_logo"
@@ -376,11 +420,55 @@
                             android:layout_height="match_parent"
                             android:visibility="gone">
 
-                            <com.github.mikephil.charting.charts.PieChart
+                            <FrameLayout
                                 android:id="@+id/step_pie_chart_fitbit"
                                 android:layout_width="match_parent"
-                                android:layout_height="match_parent"
-                                android:gravity="center" />
+                                android:layout_height="match_parent">
+
+                                <com.google.android.material.progressindicator.CircularProgressIndicator
+                                    android:id="@+id/step_ring_fitbit"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_gravity="center"
+                                    android:progress="0"
+                                    android:max="100"
+                                    app:indicatorSize="160dp"
+                                    app:trackThickness="12dp"
+                                    app:indicatorColor="@color/actifitRed"
+                                    app:trackColor="#E0E0E0"
+                                    app:trackCornerRadius="6dp" />
+
+                                <LinearLayout
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_gravity="center"
+                                    android:orientation="vertical"
+                                    android:gravity="center">
+
+                                    <TextView
+                                        android:id="@+id/tv_step_count_fitbit"
+                                        android:layout_width="wrap_content"
+                                        android:layout_height="wrap_content"
+                                        android:textColor="@color/actifitRed"
+                                        android:textSize="28sp"
+                                        android:textStyle="bold"
+                                        android:text="0" />
+
+                                    <TextView
+                                        android:id="@+id/tv_step_goal_fitbit"
+                                        android:layout_width="wrap_content"
+                                        android:layout_height="wrap_content"
+                                        android:textSize="11sp"
+                                        android:text="/ 10,000 steps" />
+
+                                    <TextView
+                                        android:id="@+id/tv_step_pct_fitbit"
+                                        android:layout_width="wrap_content"
+                                        android:layout_height="wrap_content"
+                                        android:textSize="10sp"
+                                        android:text="0% to goal" />
+                                </LinearLayout>
+                            </FrameLayout>
 
                             <ImageView
                                 android:id="@+id/fitbit_logo"
@@ -436,15 +524,60 @@
 
                         <!-- Default Actifit pie chart -->
                         <RelativeLayout
+                            android:id="@+id/default_chart_container"
                             android:layout_width="match_parent"
                             android:layout_height="match_parent"
                             android:visibility="visible">
 
-                            <com.github.mikephil.charting.charts.PieChart
+                            <FrameLayout
                                 android:id="@+id/step_pie_chart"
                                 android:layout_width="match_parent"
-                                android:layout_height="match_parent"
-                                android:gravity="center" />
+                                android:layout_height="match_parent">
+
+                                <com.google.android.material.progressindicator.CircularProgressIndicator
+                                    android:id="@+id/step_ring"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_gravity="center"
+                                    android:progress="0"
+                                    android:max="100"
+                                    app:indicatorSize="160dp"
+                                    app:trackThickness="12dp"
+                                    app:indicatorColor="@color/actifitRed"
+                                    app:trackColor="#E0E0E0"
+                                    app:trackCornerRadius="6dp" />
+
+                                <LinearLayout
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_gravity="center"
+                                    android:orientation="vertical"
+                                    android:gravity="center">
+
+                                    <TextView
+                                        android:id="@+id/tv_step_count"
+                                        android:layout_width="wrap_content"
+                                        android:layout_height="wrap_content"
+                                        android:textColor="@color/actifitRed"
+                                        android:textSize="28sp"
+                                        android:textStyle="bold"
+                                        android:text="0" />
+
+                                    <TextView
+                                        android:id="@+id/tv_step_goal"
+                                        android:layout_width="wrap_content"
+                                        android:layout_height="wrap_content"
+                                        android:textSize="11sp"
+                                        android:text="/ 10,000 steps" />
+
+                                    <TextView
+                                        android:id="@+id/tv_step_pct"
+                                        android:layout_width="wrap_content"
+                                        android:layout_height="wrap_content"
+                                        android:textSize="10sp"
+                                        android:text="0% to goal" />
+                                </LinearLayout>
+                            </FrameLayout>
 
                             <LinearLayout
                                 android:layout_width="wrap_content"
@@ -529,6 +662,56 @@
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 
+            <!-- Smart Nudge Card (P1-3) -->
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/nudge_card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/spacing_sm"
+                app:cardCornerRadius="@dimen/card_corner_radius"
+                app:cardElevation="@dimen/card_elevation"
+                app:cardBackgroundColor="@color/md_theme_cardBackground"
+                android:visibility="gone">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:padding="@dimen/spacing_md"
+                    android:gravity="center_vertical">
+
+                    <TextView
+                        android:id="@+id/tv_nudge_icon"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:fontFamily="@font/font_awesome_6_solid"
+                        android:textColor="@color/md_theme_primary"
+                        android:textSize="20sp"
+                        android:text=""
+                        tools:ignore="HardcodedText" />
+
+                    <TextView
+                        android:id="@+id/tv_nudge_message"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:paddingStart="@dimen/spacing_sm"
+                        android:paddingEnd="@dimen/spacing_xs"
+                        android:textSize="13sp" />
+
+                    <TextView
+                        android:id="@+id/tv_nudge_dismiss"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:fontFamily="@font/font_awesome_6_solid"
+                        android:textColor="@color/md_theme_primary"
+                        android:textSize="16sp"
+                        android:padding="4dp"
+                        android:text=""
+                        tools:ignore="HardcodedText" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
             <!-- Quick Actions Row -->
             <LinearLayout
                 android:layout_width="match_parent"
@@ -559,12 +742,13 @@
                     android:fontFamily="@font/font_awesome_6_solid" />
             </LinearLayout>
 
-            <!-- Voting Status -->
+            <!-- Voting Status (hidden — replaced by nudge card) -->
             <LinearLayout
                 android:id="@+id/voting_status_container"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"
+                android:visibility="gone"
                 android:paddingStart="@dimen/spacing_sm"
                 android:paddingBottom="@dimen/spacing_sm"
                 android:weightSum="1.0">
@@ -594,26 +778,60 @@
                 android:id="@+id/earnings_panel"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
+                android:orientation="vertical"
                 android:paddingStart="@dimen/spacing_sm"
-                android:paddingBottom="@dimen/spacing_sm"
-                android:weightSum="1.0">
+                android:paddingBottom="@dimen/spacing_sm">
 
-                <TextView
-                    android:id="@+id/token_notice"
-                    android:layout_width="25dp"
-                    android:layout_height="25dp"
-                    android:textColor="@color/md_theme_primary"
-                    android:textSize="20sp"
-                    android:text="@string/fa_exclamation_circle_solid"
-                    android:fontFamily="@font/font_awesome_6_solid" />
+                <!-- Estimated AFIT reward row (P1-5) -->
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:paddingBottom="@dimen/spacing_xs">
 
-                <ImageView
-                    android:id="@+id/afit_logo"
-                    android:contentDescription="AFIT icon"
-                    android:src="@drawable/actifit_logo"
-                    android:layout_height="25dp"
-                    android:layout_width="25dp" />
+                    <ImageView
+                        android:id="@+id/afit_logo"
+                        android:contentDescription="AFIT icon"
+                        android:src="@drawable/actifit_logo"
+                        android:layout_height="20dp"
+                        android:layout_width="20dp" />
+
+                    <TextView
+                        android:id="@+id/tv_reward_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:paddingStart="@dimen/spacing_xs"
+                        android:text="Est. Reward:"
+                        android:textSize="13sp"
+                        tools:ignore="HardcodedText" />
+
+                    <TextView
+                        android:id="@+id/tv_estimated_afit"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:paddingStart="@dimen/spacing_xs"
+                        android:textSize="13sp"
+                        android:textStyle="bold"
+                        android:textColor="@color/actifitRed"
+                        android:text="..." />
+                </LinearLayout>
+
+                <!-- Token logos row (blockchain breakdown) -->
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical">
+
+                    <TextView
+                        android:id="@+id/token_notice"
+                        android:layout_width="25dp"
+                        android:layout_height="25dp"
+                        android:textColor="@color/md_theme_primary"
+                        android:textSize="20sp"
+                        android:text="@string/fa_exclamation_circle_solid"
+                        android:fontFamily="@font/font_awesome_6_solid" />
 
                 <ImageView
                     android:id="@+id/hive_logo"
@@ -643,6 +861,7 @@
                     android:src="@drawable/sports"
                     android:layout_width="25dp"
                     android:layout_height="25dp" />
+                </LinearLayout>
             </LinearLayout>
 
             <!-- User Gadgets -->

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -662,6 +662,138 @@
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 
+            <!-- Streak Strip Card (P2-1) -->
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/streak_card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/spacing_sm"
+                app:cardCornerRadius="@dimen/card_corner_radius"
+                app:cardElevation="@dimen/card_elevation"
+                app:cardBackgroundColor="@color/md_theme_cardBackground">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:paddingStart="@dimen/spacing_md"
+                    android:paddingEnd="@dimen/spacing_md"
+                    android:paddingTop="@dimen/spacing_sm"
+                    android:paddingBottom="@dimen/spacing_sm">
+
+                    <!-- Header: fire icon + label + streak count -->
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical"
+                        android:paddingBottom="@dimen/spacing_xs">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:fontFamily="@font/font_awesome_6_solid"
+                            android:textColor="@color/md_theme_warning"
+                            android:textSize="16sp"
+                            android:text="&#xf06d;"
+                            tools:ignore="HardcodedText" />
+
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:paddingStart="8dp"
+                            android:text="Consistency"
+                            android:textSize="14sp"
+                            android:textStyle="bold"
+                            android:textColor="@color/md_theme_onSurface"
+                            tools:ignore="HardcodedText" />
+
+                        <TextView
+                            android:id="@+id/tv_streak_count"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:textSize="13sp"
+                            android:textColor="@color/actifitRed"
+                            android:textStyle="bold"
+                            android:text="0 day streak"
+                            tools:ignore="HardcodedText" />
+                    </LinearLayout>
+
+                    <!-- 7 day circles -->
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:weightSum="7">
+
+                        <LinearLayout android:layout_width="0dp" android:layout_height="wrap_content"
+                            android:layout_weight="1" android:orientation="vertical" android:gravity="center">
+                            <View android:id="@+id/streak_day_0" android:layout_width="28dp" android:layout_height="28dp"
+                                android:background="@drawable/streak_day_inactive" />
+                            <TextView android:id="@+id/streak_label_0" android:layout_width="wrap_content"
+                                android:layout_height="wrap_content" android:textSize="10sp" android:paddingTop="3dp" android:text="M"
+                                tools:ignore="HardcodedText" />
+                        </LinearLayout>
+
+                        <LinearLayout android:layout_width="0dp" android:layout_height="wrap_content"
+                            android:layout_weight="1" android:orientation="vertical" android:gravity="center">
+                            <View android:id="@+id/streak_day_1" android:layout_width="28dp" android:layout_height="28dp"
+                                android:background="@drawable/streak_day_inactive" />
+                            <TextView android:id="@+id/streak_label_1" android:layout_width="wrap_content"
+                                android:layout_height="wrap_content" android:textSize="10sp" android:paddingTop="3dp" android:text="T"
+                                tools:ignore="HardcodedText" />
+                        </LinearLayout>
+
+                        <LinearLayout android:layout_width="0dp" android:layout_height="wrap_content"
+                            android:layout_weight="1" android:orientation="vertical" android:gravity="center">
+                            <View android:id="@+id/streak_day_2" android:layout_width="28dp" android:layout_height="28dp"
+                                android:background="@drawable/streak_day_inactive" />
+                            <TextView android:id="@+id/streak_label_2" android:layout_width="wrap_content"
+                                android:layout_height="wrap_content" android:textSize="10sp" android:paddingTop="3dp" android:text="W"
+                                tools:ignore="HardcodedText" />
+                        </LinearLayout>
+
+                        <LinearLayout android:layout_width="0dp" android:layout_height="wrap_content"
+                            android:layout_weight="1" android:orientation="vertical" android:gravity="center">
+                            <View android:id="@+id/streak_day_3" android:layout_width="28dp" android:layout_height="28dp"
+                                android:background="@drawable/streak_day_inactive" />
+                            <TextView android:id="@+id/streak_label_3" android:layout_width="wrap_content"
+                                android:layout_height="wrap_content" android:textSize="10sp" android:paddingTop="3dp" android:text="T"
+                                tools:ignore="HardcodedText" />
+                        </LinearLayout>
+
+                        <LinearLayout android:layout_width="0dp" android:layout_height="wrap_content"
+                            android:layout_weight="1" android:orientation="vertical" android:gravity="center">
+                            <View android:id="@+id/streak_day_4" android:layout_width="28dp" android:layout_height="28dp"
+                                android:background="@drawable/streak_day_inactive" />
+                            <TextView android:id="@+id/streak_label_4" android:layout_width="wrap_content"
+                                android:layout_height="wrap_content" android:textSize="10sp" android:paddingTop="3dp" android:text="F"
+                                tools:ignore="HardcodedText" />
+                        </LinearLayout>
+
+                        <LinearLayout android:layout_width="0dp" android:layout_height="wrap_content"
+                            android:layout_weight="1" android:orientation="vertical" android:gravity="center">
+                            <View android:id="@+id/streak_day_5" android:layout_width="28dp" android:layout_height="28dp"
+                                android:background="@drawable/streak_day_inactive" />
+                            <TextView android:id="@+id/streak_label_5" android:layout_width="wrap_content"
+                                android:layout_height="wrap_content" android:textSize="10sp" android:paddingTop="3dp" android:text="S"
+                                tools:ignore="HardcodedText" />
+                        </LinearLayout>
+
+                        <LinearLayout android:layout_width="0dp" android:layout_height="wrap_content"
+                            android:layout_weight="1" android:orientation="vertical" android:gravity="center">
+                            <View android:id="@+id/streak_day_6" android:layout_width="28dp" android:layout_height="28dp"
+                                android:background="@drawable/streak_day_inactive" />
+                            <TextView android:id="@+id/streak_label_6" android:layout_width="wrap_content"
+                                android:layout_height="wrap_content" android:textSize="10sp" android:paddingTop="3dp" android:text="S"
+                                tools:ignore="HardcodedText" />
+                        </LinearLayout>
+
+                    </LinearLayout>
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
             <!-- Smart Nudge Card (P1-3) -->
             <com.google.android.material.card.MaterialCardView
                 android:id="@+id/nudge_card"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -844,6 +844,46 @@
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 
+            <!-- AI Insight Card (P2-2) -->
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/ai_insight_card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/spacing_sm"
+                app:cardCornerRadius="@dimen/card_corner_radius"
+                app:cardElevation="@dimen/card_elevation"
+                app:cardBackgroundColor="@color/md_theme_cardBackground"
+                android:visibility="gone">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:padding="@dimen/spacing_md"
+                    android:gravity="center_vertical">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:fontFamily="@font/font_awesome_6_solid"
+                        android:textColor="@color/md_theme_secondary"
+                        android:textSize="20sp"
+                        android:text="&#xf0eb;"
+                        tools:ignore="HardcodedText" />
+
+                    <TextView
+                        android:id="@+id/tv_ai_insight"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:paddingStart="@dimen/spacing_sm"
+                        android:textSize="13sp"
+                        android:lineSpacingMultiplier="1.3"
+                        android:text="Generating insight..."
+                        tools:ignore="HardcodedText" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
             <!-- Quick Actions Row -->
             <LinearLayout
                 android:layout_width="match_parent"
@@ -1008,26 +1048,48 @@
 
                 <LinearLayout
                     android:id="@+id/missing_active_gadgets_container"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    android:paddingStart="@dimen/spacing_sm">
+                    android:orientation="vertical"
+                    android:padding="@dimen/spacing_sm">
 
-                    <TextView
-                        android:layout_width="25dp"
-                        android:layout_height="25dp"
-                        android:fontFamily="@font/font_awesome_6_solid"
-                        android:textColor="@color/md_theme_primary"
-                        android:text="\uf54e"
-                        android:textSize="20sp" />
-
-                    <TextView
-                        android:id="@+id/missing_active_gadgets"
+                    <LinearLayout
                         android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:text="@string/no_active_gadgets_found"
-                        android:paddingStart="@dimen/spacing_sm"
-                        android:paddingEnd="@dimen/spacing_sm" />
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical">
+
+                        <TextView
+                            android:layout_width="28dp"
+                            android:layout_height="28dp"
+                            android:fontFamily="@font/font_awesome_6_solid"
+                            android:textColor="@color/md_theme_primary"
+                            android:gravity="center"
+                            android:text="\uf135"
+                            android:textSize="18sp"
+                            tools:ignore="HardcodedText" />
+
+                        <TextView
+                            android:id="@+id/missing_active_gadgets"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:paddingStart="@dimen/spacing_sm"
+                            android:textSize="13sp"
+                            android:textStyle="bold"
+                            android:text="Activate a Gadget \u2014 Boost earnings up to 2\u00d7"
+                            tools:ignore="HardcodedText" />
+                    </LinearLayout>
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/btn_browse_market_gadgets"
+                        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/spacing_xs"
+                        android:text="Browse Market"
+                        android:textSize="12sp"
+                        tools:ignore="HardcodedText" />
                 </LinearLayout>
             </LinearLayout>
 
@@ -1186,6 +1248,62 @@
                     android:visibility="gone"
                     android:text="@string/hourly" />
             </LinearLayout>
+
+            <!-- Monthly Heatmap (P2-5) -->
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/heatmap_card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/spacing_md"
+                app:cardCornerRadius="@dimen/card_corner_radius"
+                app:cardElevation="@dimen/card_elevation"
+                app:cardBackgroundColor="@color/md_theme_cardBackground">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:paddingStart="@dimen/spacing_md"
+                    android:paddingEnd="@dimen/spacing_md"
+                    android:paddingTop="@dimen/spacing_sm"
+                    android:paddingBottom="@dimen/spacing_sm">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical"
+                        android:paddingBottom="@dimen/spacing_xs">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:fontFamily="@font/font_awesome_6_solid"
+                            android:textColor="@color/actifitRed"
+                            android:textSize="14sp"
+                            android:text="&#xf133;"
+                            tools:ignore="HardcodedText" />
+
+                        <TextView
+                            android:id="@+id/tv_heatmap_title"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:paddingStart="8dp"
+                            android:text="This Month"
+                            android:textSize="14sp"
+                            android:textStyle="bold"
+                            android:textColor="@color/md_theme_onSurface"
+                            tools:ignore="HardcodedText" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:id="@+id/heatmap_grid"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
 
             <!-- Workout Highlight -->
             <LinearLayout

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -914,6 +914,60 @@
                     android:fontFamily="@font/font_awesome_6_solid" />
             </LinearLayout>
 
+            <!-- Earnings & Gadgets Card -->
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/earnings_gadgets_card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/spacing_md"
+                app:cardCornerRadius="@dimen/card_corner_radius"
+                app:cardElevation="@dimen/card_elevation"
+                app:cardBackgroundColor="@color/md_theme_cardBackground">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:paddingStart="@dimen/spacing_md"
+                    android:paddingEnd="@dimen/spacing_md"
+                    android:paddingTop="@dimen/spacing_sm"
+                    android:paddingBottom="@dimen/spacing_sm">
+
+                    <!-- Card header -->
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical"
+                        android:paddingBottom="@dimen/spacing_xs">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:fontFamily="@font/font_awesome_6_solid"
+                            android:textColor="@color/actifitRed"
+                            android:textSize="14sp"
+                            android:text="&#xf4b3;"
+                            tools:ignore="HardcodedText" />
+
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:paddingStart="8dp"
+                            android:text="Earnings &amp; Gadgets"
+                            android:textSize="14sp"
+                            android:textStyle="bold"
+                            android:textColor="@color/md_theme_onSurface"
+                            tools:ignore="HardcodedText" />
+                    </LinearLayout>
+
+                    <View
+                        android:layout_width="match_parent"
+                        android:layout_height="1dp"
+                        android:background="@color/md_theme_separator"
+                        android:layout_marginBottom="@dimen/spacing_xs" />
+
             <!-- Voting Status (hidden — replaced by nudge card) -->
             <LinearLayout
                 android:id="@+id/voting_status_container"
@@ -1081,15 +1135,47 @@
                             tools:ignore="HardcodedText" />
                     </LinearLayout>
 
-                    <com.google.android.material.button.MaterialButton
+                    <LinearLayout
                         android:id="@+id/btn_browse_market_gadgets"
-                        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/spacing_xs"
-                        android:text="Browse Market"
-                        android:textSize="12sp"
-                        tools:ignore="HardcodedText" />
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical"
+                        android:paddingTop="@dimen/spacing_xs"
+                        android:paddingBottom="@dimen/spacing_xs"
+                        android:paddingEnd="@dimen/spacing_sm"
+                        android:background="?attr/selectableItemBackground"
+                        android:clickable="true"
+                        android:focusable="true">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:fontFamily="@font/font_awesome_6_solid"
+                            android:textColor="@color/actifitRed"
+                            android:textSize="13sp"
+                            android:text="&#xf54e;"
+                            tools:ignore="HardcodedText" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:paddingStart="6dp"
+                            android:textColor="@color/actifitRed"
+                            android:textSize="13sp"
+                            android:text="Open in Market"
+                            tools:ignore="HardcodedText" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:paddingStart="4dp"
+                            android:fontFamily="@font/font_awesome_6_solid"
+                            android:textColor="@color/actifitRed"
+                            android:textSize="11sp"
+                            android:text="&#xf054;"
+                            tools:ignore="HardcodedText" />
+                    </LinearLayout>
                 </LinearLayout>
             </LinearLayout>
 
@@ -1131,6 +1217,9 @@
                     android:textSize="@dimen/text_subtitle"
                     android:paddingStart="@dimen/spacing_sm" />
             </LinearLayout>
+
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
 
             <!-- Rewards Row -->
             <LinearLayout

--- a/app/src/main/res/layout/bottom_sheet_more_menu.xml
+++ b/app/src/main/res/layout/bottom_sheet_more_menu.xml
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingBottom="16dp">
+
+    <!-- Drag handle -->
+    <View
+        android:layout_width="40dp"
+        android:layout_height="4dp"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="10dp"
+        android:layout_marginBottom="6dp"
+        android:background="@drawable/drag_handle_bg" />
+
+    <!-- Sheet title -->
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="20dp"
+        android:paddingEnd="20dp"
+        android:paddingTop="4dp"
+        android:paddingBottom="12dp"
+        android:text="More"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        android:textColor="@color/md_theme_primary"
+        tools:ignore="HardcodedText" />
+
+    <!-- Divider -->
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/md_theme_background"
+        android:layout_marginBottom="4dp" />
+
+    <!-- History -->
+    <LinearLayout
+        android:id="@+id/more_item_history"
+        android:layout_width="match_parent"
+        android:layout_height="52dp"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:paddingStart="20dp"
+        android:paddingEnd="20dp"
+        android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true">
+
+        <TextView
+            android:layout_width="32dp"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:fontFamily="@font/font_awesome_6_solid"
+            android:textColor="@color/actifitRed"
+            android:textSize="18sp"
+            android:text="&#xf1da;" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="16dp"
+            android:textSize="15sp"
+            android:text="Activity History"
+            tools:ignore="HardcodedText" />
+    </LinearLayout>
+
+    <!-- Videos -->
+    <LinearLayout
+        android:id="@+id/more_item_videos"
+        android:layout_width="match_parent"
+        android:layout_height="52dp"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:paddingStart="20dp"
+        android:paddingEnd="20dp"
+        android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true">
+
+        <TextView
+            android:layout_width="32dp"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:fontFamily="@font/font_awesome_6_solid"
+            android:textColor="@color/actifitRed"
+            android:textSize="18sp"
+            android:text="&#xf03d;" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="16dp"
+            android:textSize="15sp"
+            android:text="Upload Video"
+            tools:ignore="HardcodedText" />
+    </LinearLayout>
+
+    <!-- Socials -->
+    <LinearLayout
+        android:id="@+id/more_item_socials"
+        android:layout_width="match_parent"
+        android:layout_height="52dp"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:paddingStart="20dp"
+        android:paddingEnd="20dp"
+        android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true">
+
+        <TextView
+            android:layout_width="32dp"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:fontFamily="@font/font_awesome_6_solid"
+            android:textColor="@color/actifitRed"
+            android:textSize="18sp"
+            android:text="&#xe4e2;" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="16dp"
+            android:textSize="15sp"
+            android:text="Social Feed"
+            tools:ignore="HardcodedText" />
+    </LinearLayout>
+
+    <!-- Help -->
+    <LinearLayout
+        android:id="@+id/more_item_help"
+        android:layout_width="match_parent"
+        android:layout_height="52dp"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:paddingStart="20dp"
+        android:paddingEnd="20dp"
+        android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true">
+
+        <TextView
+            android:layout_width="32dp"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:fontFamily="@font/font_awesome_6_solid"
+            android:textColor="@color/actifitRed"
+            android:textSize="18sp"
+            android:text="&#xf059;" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="16dp"
+            android:textSize="15sp"
+            android:text="Help &amp; FAQ"
+            tools:ignore="HardcodedText" />
+    </LinearLayout>
+
+    <!-- Chat -->
+    <LinearLayout
+        android:id="@+id/more_item_chat"
+        android:layout_width="match_parent"
+        android:layout_height="52dp"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:paddingStart="20dp"
+        android:paddingEnd="20dp"
+        android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true">
+
+        <TextView
+            android:layout_width="32dp"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:fontFamily="@font/font_awesome_6_solid"
+            android:textColor="@color/actifitRed"
+            android:textSize="18sp"
+            android:text="&#xf086;" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="16dp"
+            android:textSize="15sp"
+            android:text="Community Chat"
+            tools:ignore="HardcodedText" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/bottom_sheet_more_menu.xml
+++ b/app/src/main/res/layout/bottom_sheet_more_menu.xml
@@ -127,7 +127,7 @@
             android:layout_height="wrap_content"
             android:paddingStart="16dp"
             android:textSize="15sp"
-            android:text="Social Feed"
+            android:text="Follow Us"
             tools:ignore="HardcodedText" />
     </LinearLayout>
 

--- a/app/src/main/res/layout/footer_menu.xml
+++ b/app/src/main/res/layout/footer_menu.xml
@@ -1,123 +1,120 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal"
-    android:gravity="center"
+    android:gravity="center_vertical"
     android:background="?android:attr/windowBackground"
     android:paddingTop="8dp"
-    android:paddingBottom="8dp"
-    android:divider="@drawable/menu_divider"
-    android:showDividers="middle"
-    android:dividerPadding="5dp"
-    >
+    android:paddingBottom="8dp">
 
     <TextView
         android:id="@+id/btn_home"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:gravity="center"
         android:fontFamily="@font/font_awesome_6_solid"
         android:textColor="@color/footer_menu_text_color"
-        android:text="\uf015"
+        android:text=""
         android:textSize="23sp"
-        android:padding="5dp"
-        />
+        android:padding="5dp" />
 
     <TextView
         android:id="@+id/btn_view_social"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:gravity="center"
         android:fontFamily="@font/font_awesome_6_solid"
         android:textColor="@color/footer_menu_text_color"
-        android:text="\ue068"
+        android:text=""
         android:textSize="23sp"
         android:padding="5dp" />
 
     <TextView
         android:id="@+id/btn_view_market"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:gravity="center"
         android:fontFamily="@font/font_awesome_6_solid"
         android:textColor="@color/footer_menu_text_color"
-        android:text="\uf54e"
+        android:text=""
         android:textSize="23sp"
         android:padding="5dp" />
 
     <TextView
+        android:id="@+id/btn_view_leaderboard"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:gravity="center"
+        android:fontFamily="@font/font_awesome_6_solid"
+        android:textColor="@color/footer_menu_text_color"
+        android:text=""
+        android:textSize="23sp"
+        android:padding="5dp" />
+
+    <TextView
+        android:id="@+id/btn_more_footer"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:gravity="center"
+        android:fontFamily="@font/font_awesome_6_solid"
+        android:textColor="@color/footer_menu_text_color"
+        android:text=""
+        android:textSize="23sp"
+        android:padding="5dp" />
+
+    <!-- Hidden items — accessible via More menu -->
+    <TextView
         android:id="@+id/btn_view_history"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:fontFamily="@font/font_awesome_6_solid"
         android:textColor="@color/footer_menu_text_color"
         android:text="@string/fa_history_solid"
         android:textSize="23sp"
-        android:padding="5dp"
         android:visibility="gone" />
 
     <TextView
-        android:id="@+id/btn_view_leaderboard"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:fontFamily="@font/font_awesome_6_solid"
-        android:textColor="@color/footer_menu_text_color"
-        android:text="\uf0cb"
-        android:textSize="23sp"
-        android:padding="5dp" />
-
-    <!--
-</LinearLayout>
-
-
-<LinearLayout
-    android:orientation="horizontal"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:gravity="center">
-    -->
-
-    <!-- Row 2 (hidden \u2014 moved to More menu) -->
-
-    <TextView
         android:id="@+id/btn_video"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:fontFamily="@font/font_awesome_6_solid"
         android:textColor="@color/footer_menu_text_color"
-        android:text="\uf03d"
+        android:text=""
         android:textSize="23sp"
-        android:padding="5dp"
         android:visibility="gone" />
 
     <TextView
         android:id="@+id/btn_socials"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:fontFamily="@font/font_awesome_6_solid"
         android:textColor="@color/footer_menu_text_color"
-        android:text="\ue4e2"
+        android:text=""
         android:textSize="23sp"
-        android:padding="5dp"
         android:visibility="gone" />
 
     <TextView
         android:id="@+id/btn_help"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:fontFamily="@font/font_awesome_6_solid"
         android:textColor="@color/footer_menu_text_color"
         android:text="/?"
         android:textSize="23sp"
-        android:padding="5dp"
         android:visibility="gone" />
 
     <LinearLayout
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:baselineAligned="false"
         android:visibility="gone">
 
         <TextView
@@ -126,32 +123,21 @@
             android:layout_height="wrap_content"
             android:fontFamily="@font/font_awesome_6_solid"
             android:textColor="@color/footer_menu_text_color"
-            android:text="\uf086"
+            android:text=""
             android:textSize="23sp"
             android:padding="5dp" />
 
-        <TextView android:id="@+id/chat_notif_count"
+        <TextView
+            android:id="@+id/chat_notif_count"
             android:layout_width="wrap_content"
             android:layout_height="15dp"
             android:layout_gravity="top|start"
             android:paddingTop="2dp"
             android:textColor="@color/actifitRed"
             android:fontFamily="@font/font_awesome_6_solid"
-            android:text="\uf111"
+            android:text=""
             android:textSize="11sp"
             android:visibility="visible" />
-
     </LinearLayout>
-
-    <!-- More button (5th visible item) -->
-    <TextView
-        android:id="@+id/btn_more_footer"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:fontFamily="@font/font_awesome_6_solid"
-        android:textColor="@color/footer_menu_text_color"
-        android:text="\uf141"
-        android:textSize="23sp"
-        android:padding="5dp" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/footer_menu.xml
+++ b/app/src/main/res/layout/footer_menu.xml
@@ -1,74 +1,194 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal"
-    android:gravity="center_vertical"
     android:background="?android:attr/windowBackground"
-    android:paddingTop="8dp"
-    android:paddingBottom="8dp">
+    android:elevation="8dp"
+    android:paddingTop="6dp"
+    android:paddingBottom="10dp">
 
-    <TextView
+    <!-- Home -->
+    <LinearLayout
         android:id="@+id/btn_home"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
+        android:orientation="vertical"
         android:gravity="center"
-        android:fontFamily="@font/font_awesome_6_solid"
-        android:textColor="@color/footer_menu_text_color"
-        android:text=""
-        android:textSize="23sp"
-        android:padding="5dp" />
+        android:paddingTop="2dp"
+        android:paddingBottom="2dp"
+        android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true">
 
-    <TextView
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:fontFamily="@font/font_awesome_6_solid"
+            android:textColor="@color/footer_menu_text_color"
+            android:text="&#xe068;"
+            android:textSize="20sp"
+            android:duplicateParentState="true"
+            tools:ignore="HardcodedText" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Home"
+            android:textSize="10sp"
+            android:textColor="@color/footer_menu_text_color"
+            android:paddingTop="2dp"
+            android:duplicateParentState="true"
+            tools:ignore="HardcodedText" />
+    </LinearLayout>
+
+    <!-- Social -->
+    <LinearLayout
         android:id="@+id/btn_view_social"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
+        android:orientation="vertical"
         android:gravity="center"
-        android:fontFamily="@font/font_awesome_6_solid"
-        android:textColor="@color/footer_menu_text_color"
-        android:text=""
-        android:textSize="23sp"
-        android:padding="5dp" />
+        android:paddingTop="2dp"
+        android:paddingBottom="2dp"
+        android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true">
 
-    <TextView
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:fontFamily="@font/font_awesome_6_solid"
+            android:textColor="@color/footer_menu_text_color"
+            android:text="&#xe4e2;"
+            android:textSize="20sp"
+            android:duplicateParentState="true"
+            tools:ignore="HardcodedText" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Social"
+            android:textSize="10sp"
+            android:textColor="@color/footer_menu_text_color"
+            android:paddingTop="2dp"
+            android:duplicateParentState="true"
+            tools:ignore="HardcodedText" />
+    </LinearLayout>
+
+    <!-- Market -->
+    <LinearLayout
         android:id="@+id/btn_view_market"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
+        android:orientation="vertical"
         android:gravity="center"
-        android:fontFamily="@font/font_awesome_6_solid"
-        android:textColor="@color/footer_menu_text_color"
-        android:text=""
-        android:textSize="23sp"
-        android:padding="5dp" />
+        android:paddingTop="2dp"
+        android:paddingBottom="2dp"
+        android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true">
 
-    <TextView
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:fontFamily="@font/font_awesome_6_solid"
+            android:textColor="@color/footer_menu_text_color"
+            android:text="&#xf54e;"
+            android:textSize="20sp"
+            android:duplicateParentState="true"
+            tools:ignore="HardcodedText" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Market"
+            android:textSize="10sp"
+            android:textColor="@color/footer_menu_text_color"
+            android:paddingTop="2dp"
+            android:duplicateParentState="true"
+            tools:ignore="HardcodedText" />
+    </LinearLayout>
+
+    <!-- Leaderboard -->
+    <LinearLayout
         android:id="@+id/btn_view_leaderboard"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
+        android:orientation="vertical"
         android:gravity="center"
-        android:fontFamily="@font/font_awesome_6_solid"
-        android:textColor="@color/footer_menu_text_color"
-        android:text=""
-        android:textSize="23sp"
-        android:padding="5dp" />
+        android:paddingTop="2dp"
+        android:paddingBottom="2dp"
+        android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true">
 
-    <TextView
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:fontFamily="@font/font_awesome_6_solid"
+            android:textColor="@color/footer_menu_text_color"
+            android:text="&#xf091;"
+            android:textSize="20sp"
+            android:duplicateParentState="true"
+            tools:ignore="HardcodedText" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Leaders"
+            android:textSize="10sp"
+            android:textColor="@color/footer_menu_text_color"
+            android:paddingTop="2dp"
+            android:duplicateParentState="true"
+            tools:ignore="HardcodedText" />
+    </LinearLayout>
+
+    <!-- More -->
+    <LinearLayout
         android:id="@+id/btn_more_footer"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
+        android:orientation="vertical"
         android:gravity="center"
-        android:fontFamily="@font/font_awesome_6_solid"
-        android:textColor="@color/footer_menu_text_color"
-        android:text=""
-        android:textSize="23sp"
-        android:padding="5dp" />
+        android:paddingTop="2dp"
+        android:paddingBottom="2dp"
+        android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:fontFamily="@font/font_awesome_6_solid"
+            android:textColor="@color/footer_menu_text_color"
+            android:text="&#xf141;"
+            android:textSize="20sp"
+            android:duplicateParentState="true"
+            tools:ignore="HardcodedText" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="More"
+            android:textSize="10sp"
+            android:textColor="@color/footer_menu_text_color"
+            android:paddingTop="2dp"
+            android:duplicateParentState="true"
+            tools:ignore="HardcodedText" />
+    </LinearLayout>
 
     <!-- Hidden items — accessible via More menu -->
     <TextView
@@ -87,7 +207,7 @@
         android:layout_height="wrap_content"
         android:fontFamily="@font/font_awesome_6_solid"
         android:textColor="@color/footer_menu_text_color"
-        android:text=""
+        android:text="&#xf03d;"
         android:textSize="23sp"
         android:visibility="gone" />
 
@@ -97,7 +217,7 @@
         android:layout_height="wrap_content"
         android:fontFamily="@font/font_awesome_6_solid"
         android:textColor="@color/footer_menu_text_color"
-        android:text=""
+        android:text="&#xe4e2;"
         android:textSize="23sp"
         android:visibility="gone" />
 
@@ -123,7 +243,7 @@
             android:layout_height="wrap_content"
             android:fontFamily="@font/font_awesome_6_solid"
             android:textColor="@color/footer_menu_text_color"
-            android:text=""
+            android:text="&#xf086;"
             android:textSize="23sp"
             android:padding="5dp" />
 
@@ -135,7 +255,7 @@
             android:paddingTop="2dp"
             android:textColor="@color/actifitRed"
             android:fontFamily="@font/font_awesome_6_solid"
-            android:text=""
+            android:text="&#xf111;"
             android:textSize="11sp"
             android:visibility="visible" />
     </LinearLayout>

--- a/app/src/main/res/layout/footer_menu.xml
+++ b/app/src/main/res/layout/footer_menu.xml
@@ -54,7 +54,8 @@
         android:textColor="@color/footer_menu_text_color"
         android:text="@string/fa_history_solid"
         android:textSize="23sp"
-        android:padding="5dp" />
+        android:padding="5dp"
+        android:visibility="gone" />
 
     <TextView
         android:id="@+id/btn_view_leaderboard"
@@ -77,7 +78,7 @@
     android:gravity="center">
     -->
 
-    <!-- Row 2 -->
+    <!-- Row 2 (hidden \u2014 moved to More menu) -->
 
     <TextView
         android:id="@+id/btn_video"
@@ -87,7 +88,8 @@
         android:textColor="@color/footer_menu_text_color"
         android:text="\uf03d"
         android:textSize="23sp"
-        android:padding="5dp" />
+        android:padding="5dp"
+        android:visibility="gone" />
 
     <TextView
         android:id="@+id/btn_socials"
@@ -97,7 +99,8 @@
         android:textColor="@color/footer_menu_text_color"
         android:text="\ue4e2"
         android:textSize="23sp"
-        android:padding="5dp" />
+        android:padding="5dp"
+        android:visibility="gone" />
 
     <TextView
         android:id="@+id/btn_help"
@@ -107,37 +110,48 @@
         android:textColor="@color/footer_menu_text_color"
         android:text="/?"
         android:textSize="23sp"
-        android:padding="5dp" />
+        android:padding="5dp"
+        android:visibility="gone" />
 
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:baselineAligned="false"
-        >
+        android:visibility="gone">
 
+        <TextView
+            android:id="@+id/btn_chat"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/font_awesome_6_solid"
+            android:textColor="@color/footer_menu_text_color"
+            android:text="\uf086"
+            android:textSize="23sp"
+            android:padding="5dp" />
+
+        <TextView android:id="@+id/chat_notif_count"
+            android:layout_width="wrap_content"
+            android:layout_height="15dp"
+            android:layout_gravity="top|start"
+            android:paddingTop="2dp"
+            android:textColor="@color/actifitRed"
+            android:fontFamily="@font/font_awesome_6_solid"
+            android:text="\uf111"
+            android:textSize="11sp"
+            android:visibility="visible" />
+
+    </LinearLayout>
+
+    <!-- More button (5th visible item) -->
     <TextView
-        android:id="@+id/btn_chat"
+        android:id="@+id/btn_more_footer"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:fontFamily="@font/font_awesome_6_solid"
         android:textColor="@color/footer_menu_text_color"
-        android:text="\uf086"
+        android:text="\uf141"
         android:textSize="23sp"
         android:padding="5dp" />
-
-    <TextView android:id="@+id/chat_notif_count"
-        android:layout_width="wrap_content"
-        android:layout_height="15dp"
-        android:layout_gravity="top|start"
-        android:paddingTop="2dp"
-        android:textColor="@color/actifitRed"
-        android:fontFamily="@font/font_awesome_6_solid"
-        android:text="\uf111"
-        android:textSize="11sp"
-        android:visibility="visible"
-        />
-
-    </LinearLayout>
 
 </LinearLayout>

--- a/tasks/tasklist.md
+++ b/tasks/tasklist.md
@@ -34,10 +34,44 @@ Organized by priority. All tasks are UI/UX enhancements unless otherwise noted.
   Move Videos, Socials, Help, and Chat into a bottom sheet triggered by "More".
   _Files: activity_main.xml (footer), MainActivity.java (footer click handlers)_
 
-- [ ] **P1-5: Earnings clarity card — single "Today's Reward" number**
+- [ ] **P1-5: Earnings clarity card — estimated AFIT reward**
   Replace the four opaque token logos in the earnings panel with a single card showing
-  `Today's Estimated Reward: ~2.4 AFIT`. Tap to expand for per-token breakdown.
-  _Files: activity_main.xml (earnings panel), MainActivity.java_
+  `Estimated Reward: ~142 AFIT` sourced from a new server-side scoring endpoint.
+  Tap to expand for the per-token blockchain breakdown (HIVE/BLURT, already via
+  `/pendingRewards`).
+
+  **How the estimate is calculated (server-side, Option C):**
+  A new endpoint `GET /getEstimatedReward?user={username}` is added to the API server
+  (`c:\mo\coding\actifitbot\app.js`). It fetches the user's latest actifit post
+  (from the `verified_posts` collection or Hive blockchain), then applies the same
+  scoring formula used by the curation bot (`c:\mo\coding\actifitvoter\curation-bot.js`):
+
+  ```
+  estimated_afit = activity_score(step_count)
+                 + content_score(body_length)
+                 + media_score(image_count)
+                 + upvote_score(net_votes)
+                 + comment_score(comment_count)
+                 + moderator_score
+                 + user_rank_score(rank * rank_factor / 100)
+                 + applicable boosts
+  ```
+
+  Scoring rules and factors (activity_factor, rank_factor, etc.) must be shared or
+  replicated from actifitvoter config into actifitbot so the endpoint can run the
+  formula without cross-repo dependency at runtime.
+
+  Returns: `{ estimated_afit, post_url, post_date, already_rewarded: bool }`
+  — `already_rewarded: true` means the curation bot already ran for this post,
+  in which case the app shows "Last reward: X AFIT" instead of "Estimated".
+
+  **Work split:**
+  - Backend (`actifitbot/app.js`): new `/getEstimatedReward` endpoint + scoring logic
+  - Android (`ApiManager.java`, `activity_main.xml`, `MainActivity.java`): call endpoint,
+    display result in earnings panel replacing the token logo row
+
+  _Android files: activity_main.xml (earnings panel), ApiManager.java, MainActivity.java_
+  _Backend repo: c:\mo\coding\actifitbot\app.js_
 
 ---
 
@@ -109,7 +143,7 @@ Organized by priority. All tasks are UI/UX enhancements unless otherwise noted.
 | P1-2 | Today's Goal progress label | High | Low |
 | P1-3 | Contextual action banner | High | Low |
 | P1-4 | Condense footer to 5 items | High | Low |
-| P1-5 | Earnings clarity card | High | Low |
+| P1-5 | Earnings clarity card (estimated AFIT) | High | Medium — needs new backend endpoint |
 | P2-1 | 7-day streak tracker | High | Medium |
 | P2-2 | AI insight card (Gemini) | High | Medium |
 | P2-3 | Gadgets empty-state CTA | Medium | Low |


### PR DESCRIPTION
## Summary

A comprehensive UI/UX overhaul across all major screens, implementing Material Design 3 patterns, a fully redesigned dashboard, and numerous UX fixes.

### Dashboard (MainActivity)
- Full redesign: hero step ring (CircularProgressIndicator), streak consistency strip (7-day), AI insight card, monthly activity heatmap, quick action buttons, smart nudge card with per-mode updates
- Earnings & Gadgets card: hero AFIT reward number (22sp bold), compact token logo chips, single-line gadgets empty state
- News carousel: MaterialCardView wrapper, 130→180dp height, dark gradient overlay for floating dot indicators
- Bottom footer nav: IDs moved to parent LinearLayouts for `duplicateParentState` selected-state color propagation
- More menu implemented as a `BottomSheetDialog` wired to `BaseActivity` (works on all screens)
- Milestone celebration animation (pulse + Toast) on step count milestones
- Route tracking card placeholder (upcoming feature)

### Post Screen (PostSteemitActivity)
- Removed stepper; redesigned toolbar icons; fixed expand mode; polished char count and tag input (converts on space/comma/paste); improved activity chip layout

### Settings Screen (SettingsActivity)
- Full Material Design 3 card layout: 11 grouped cards (Activity Tracking, Appearance, Blockchain, Security, Notifications, Popup Visibility, Language, Measurement, Charity, Reminders, Data & Account)
- `CheckBox` → `MaterialSwitch`, `EditText` → `TextInputLayout`, 2-option `RadioGroup` → `MaterialButtonToggleGroup`; zero Java changes (all IDs preserved)

### Bug Fixes & Polish
- Fixed HC button clipping, notification crashes on Android 16, chart NPE, reward button bounce, login screen readability, video dialog layout, leaderboard entry layout, and 20+ other targeted fixes
- `RewardManager` rebuilt with tiered reward system and proper SharedPreferences caching
- `AiService` extended with `generateDashboardInsight()` for daily AI-powered fitness insights

## Test plan
- [ ] Dashboard: scroll all cards, toggle tracking mode, verify nudge/streak/heatmap update
- [ ] Toggle each MaterialSwitch in Settings, save, reopen — verify persistence
- [ ] Post a blockchain activity report end-to-end
- [ ] Verify bottom nav selected state coloring (Home/Social/Market/Leaderboard)
- [ ] More menu opens from any screen (MainActivity, History, etc.)
- [ ] Dark mode toggle still works
- [ ] Build: `gradlew assembleDebug` — zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)