### PR TITLE
feat: route map tracking, dashboard redesign, and UI polish

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -213,4 +213,8 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.16.0'
     annotationProcessor 'com.github.bumptech.glide:compiler:4.16.0'
 
+    // Route map feature
+    implementation 'org.osmdroid:osmdroid-android:6.1.18'
+    implementation 'com.google.android.gms:play-services-location:21.3.0'
+
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -46,6 +46,11 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_HEALTH"/>
     <!--tools:node="remove"/>-->
 
+    <!-- Route map tracking -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+
     <uses-feature
         android:name="android.hardware.camera"
         android:required="false" />
@@ -196,6 +201,13 @@
     <activity android:name=".HistoryChartActivity" />
     <activity android:name=".MarketActivity" android:windowSoftInputMode="adjustPan" />
     <activity android:name=".SocialActivity" android:windowSoftInputMode="adjustPan" />
+
+    <activity android:name=".RouteMapActivity" android:exported="false" />
+
+    <service
+        android:name=".RouteRecordingService"
+        android:foregroundServiceType="location"
+        android:exported="false" />
 
     <receiver android:name=".ResetPieChart" />
 

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/ActivityEntryAdapter.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/ActivityEntryAdapter.java
@@ -12,6 +12,9 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+
 import java.text.DecimalFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -45,6 +48,7 @@ public class ActivityEntryAdapter extends ArrayAdapter<DateStepsModel> {
         TextView detailsButton = convertView.findViewById(R.id.activityDetailsBtn);
         TextView postViewButton = convertView.findViewById(R.id.post_link);
         ProgressBar loader = convertView.findViewById(R.id.loader);
+        TextView routeButton = convertView.findViewById(R.id.btn_view_route);
         // Populate the data into the template view using the data object
         entryDate.setText(activityEntry.mDate.toString());
 
@@ -143,6 +147,20 @@ public class ActivityEntryAdapter extends ArrayAdapter<DateStepsModel> {
                 }
             }
         });
+        // Route map button
+        if (activityEntry.hasRoute && activityEntry.rawDate != 0) {
+            routeButton.setVisibility(View.VISIBLE);
+            routeButton.setOnClickListener(v -> {
+                Intent intent = new Intent(getContext(), RouteMapActivity.class);
+                intent.putExtra(RouteMapActivity.EXTRA_MODE, RouteMapActivity.MODE_VIEW);
+                intent.putExtra(RouteMapActivity.EXTRA_DATE, activityEntry.rawDate);
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                getContext().startActivity(intent);
+            });
+        } else {
+            routeButton.setVisibility(View.GONE);
+        }
+
         return convertView;
     }
 

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/DateStepsModel.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/DateStepsModel.java
@@ -8,6 +8,8 @@ public class DateStepsModel {
     public Boolean hasRelevantPost = false;
     public String relevantPostLink;
     public Boolean relevantPostChecked = false;
+    public boolean hasRoute = false;
+    public int rawDate; // yyyyMMdd int for route lookup
 
     public DateStepsModel(){
 

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
@@ -76,6 +76,8 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import android.Manifest;
+
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.AlertDialog;
@@ -332,6 +334,8 @@ public class MainActivity extends BaseActivity {
     final int activityMilestoneTwo = 7000;
     final int activityMilestoneThree = 10000;
     private int lastCelebrationMilestone = 0;
+
+    private ActivityResultLauncher<String[]> locationPermissionLauncher;
 
     private RewardedAd rewardedAd;
     private Button dailyRewardButton;
@@ -1016,6 +1020,20 @@ public class MainActivity extends BaseActivity {
             Intent intent = new Intent(ctx, WorkoutWizardActivity.class);
             startActivity(intent);
         });
+
+        locationPermissionLauncher = registerForActivityResult(
+                new ActivityResultContracts.RequestMultiplePermissions(), results -> {
+                    Boolean fine = results.getOrDefault(Manifest.permission.ACCESS_FINE_LOCATION, false);
+                    Boolean coarse = results.getOrDefault(Manifest.permission.ACCESS_COARSE_LOCATION, false);
+                    if (Boolean.TRUE.equals(fine) || Boolean.TRUE.equals(coarse)) {
+                        showActivityTypePicker();
+                    } else {
+                        Toast.makeText(this, "Location permission is required to record routes.",
+                                Toast.LENGTH_LONG).show();
+                    }
+                });
+
+        setupRouteCard();
 
         Uri returnUrl = getIntent().getData();
         if (returnUrl != null) {
@@ -2661,6 +2679,105 @@ public class MainActivity extends BaseActivity {
         });
     }
 
+    private void setupRouteCard() {
+        View btnStart = findViewById(R.id.btn_start_route_recording);
+        if (btnStart == null) return;
+        btnStart.setOnClickListener(v -> {
+            if (RouteRecordingService.isRunning) {
+                Intent intent = new Intent(this, RouteMapActivity.class);
+                intent.putExtra(RouteMapActivity.EXTRA_MODE, RouteMapActivity.MODE_LIVE);
+                startActivity(intent);
+                return;
+            }
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION)
+                    == PackageManager.PERMISSION_GRANTED) {
+                showActivityTypePicker();
+            } else {
+                locationPermissionLauncher.launch(new String[]{
+                        Manifest.permission.ACCESS_FINE_LOCATION,
+                        Manifest.permission.ACCESS_COARSE_LOCATION
+                });
+            }
+        });
+
+        TextView tvLastRouteView = findViewById(R.id.tv_last_route_view);
+        if (tvLastRouteView != null) {
+            tvLastRouteView.setOnClickListener(v -> {
+                if (mStepsDBHelper == null) return;
+                RouteModel route = mStepsDBHelper.getMostRecentRoute();
+                if (route != null) {
+                    Intent intent = new Intent(this, RouteMapActivity.class);
+                    intent.putExtra(RouteMapActivity.EXTRA_MODE, RouteMapActivity.MODE_VIEW);
+                    intent.putExtra(RouteMapActivity.EXTRA_DATE, route.date);
+                    startActivity(intent);
+                }
+            });
+        }
+    }
+
+    private void loadLastRoute() {
+        if (mStepsDBHelper == null) return;
+        RouteModel route = mStepsDBHelper.getMostRecentRoute();
+        LinearLayout summary = findViewById(R.id.last_route_summary);
+        TextView tvInfo = findViewById(R.id.tv_last_route_info);
+        if (summary == null || tvInfo == null) return;
+        if (route != null) {
+            tvInfo.setText(route.getFormattedDistance() + "  •  " + route.getFormattedDuration()
+                    + "  •  " + (route.activityType != null ? route.activityType : ""));
+            summary.setVisibility(View.VISIBLE);
+        } else {
+            summary.setVisibility(View.GONE);
+        }
+    }
+
+    private void showActivityTypePicker() {
+        String[] outdoorTypes = {"Walking", "Running", "Cycling", "Hiking", "Jogging",
+                "Skating", "Skiing", "Geocaching", "Photowalking", "Plogging",
+                "Sailing", "Scootering", "Kayaking"};
+
+        com.google.android.material.bottomsheet.BottomSheetDialog sheet =
+                new com.google.android.material.bottomsheet.BottomSheetDialog(this);
+        android.view.View sheetView = getLayoutInflater().inflate(
+                R.layout.bottom_sheet_activity_picker, null);
+        com.google.android.material.chip.ChipGroup chipGroup =
+                sheetView.findViewById(R.id.activity_type_chip_group);
+
+        for (String type : outdoorTypes) {
+            com.google.android.material.chip.Chip chip = new com.google.android.material.chip.Chip(this);
+            chip.setText(type);
+            chip.setCheckable(true);
+            chipGroup.addView(chip);
+        }
+
+        sheetView.findViewById(R.id.activity_type_chip_group);
+        sheet.setContentView(sheetView);
+
+        chipGroup.setOnCheckedStateChangeListener((group, checkedIds) -> {
+            if (!checkedIds.isEmpty()) {
+                com.google.android.material.chip.Chip selected =
+                        group.findViewById(checkedIds.get(0));
+                if (selected != null) {
+                    String actType = selected.getText().toString();
+                    sheet.dismiss();
+                    startRouteRecording(actType);
+                }
+            }
+        });
+
+        sheet.show();
+    }
+
+    private void startRouteRecording(String activityType) {
+        Intent serviceIntent = new Intent(this, RouteRecordingService.class);
+        serviceIntent.putExtra(RouteRecordingService.EXTRA_ACTIVITY_TYPE, activityType);
+        startForegroundService(serviceIntent);
+
+        Intent mapIntent = new Intent(this, RouteMapActivity.class);
+        mapIntent.putExtra(RouteMapActivity.EXTRA_MODE, RouteMapActivity.MODE_LIVE);
+        mapIntent.putExtra(RouteMapActivity.EXTRA_ACTIVITY_TYPE, activityType);
+        startActivity(mapIntent);
+    }
+
     private void buildMonthHeatmap() {
         LinearLayout heatmapGrid = findViewById(R.id.heatmap_grid);
         if (heatmapGrid == null || mStepsDBHelper == null) return;
@@ -3316,6 +3433,8 @@ public class MainActivity extends BaseActivity {
                 loadAiInsight();
 
                 buildMonthHeatmap();
+
+                loadLastRoute();
 
                 displayVotingStatus();
 

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/RouteMapActivity.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/RouteMapActivity.java
@@ -1,0 +1,292 @@
+package io.actifit.fitnesstracker.actifitfitnesstracker;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.view.View;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.core.content.ContextCompat;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import org.osmdroid.config.Configuration;
+import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
+import org.osmdroid.util.BoundingBox;
+import org.osmdroid.util.GeoPoint;
+import org.osmdroid.views.MapView;
+import org.osmdroid.views.overlay.Marker;
+import org.osmdroid.views.overlay.Polyline;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+public class RouteMapActivity extends BaseActivity {
+
+    public static final String MODE_LIVE = "LIVE";
+    public static final String MODE_VIEW = "VIEW";
+    public static final String EXTRA_MODE = "mode";
+    public static final String EXTRA_DATE = "date";
+    public static final String EXTRA_ACTIVITY_TYPE = "activityType";
+    public static final String EXTRA_ROUTE_ID = "routeId";
+
+    private MapView mapView;
+    private Polyline routePolyline;
+    private Marker currentPositionMarker;
+    private final List<GeoPoint> routePoints = new ArrayList<>();
+
+    private TextView tvDistance, tvDuration, tvPace, tvSteps, tvTimer, tvActivityLabel;
+    private LinearLayout liveControls, viewControls;
+
+    private String mode = MODE_VIEW;
+    private long recordingStartMs;
+    private double currentDistanceMeters;
+    private Handler timerHandler;
+    private Runnable timerRunnable;
+
+    private BroadcastReceiver waypointReceiver;
+    private BroadcastReceiver stoppedReceiver;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Configuration.getInstance().setUserAgentValue(getPackageName());
+
+        setContentView(R.layout.activity_route_map);
+
+        mode = getIntent().getStringExtra(EXTRA_MODE);
+        if (mode == null) mode = MODE_VIEW;
+
+        mapView = findViewById(R.id.route_map_view);
+        mapView.setTileSource(TileSourceFactory.MAPNIK);
+        mapView.setMultiTouchControls(true);
+        mapView.getController().setZoom(16.0);
+
+        tvDistance = findViewById(R.id.tv_route_distance);
+        tvDuration = findViewById(R.id.tv_route_duration);
+        tvPace = findViewById(R.id.tv_route_pace);
+        tvSteps = findViewById(R.id.tv_route_steps);
+        tvTimer = findViewById(R.id.tv_route_timer);
+        tvActivityLabel = findViewById(R.id.tv_route_activity_label);
+        liveControls = findViewById(R.id.live_controls);
+        viewControls = findViewById(R.id.view_controls);
+
+        routePolyline = new Polyline();
+        routePolyline.getOutlinePaint().setColor(ContextCompat.getColor(this, R.color.actifitRed));
+        routePolyline.getOutlinePaint().setStrokeWidth(10f);
+        mapView.getOverlays().add(routePolyline);
+
+        currentPositionMarker = new Marker(mapView);
+        currentPositionMarker.setIcon(ContextCompat.getDrawable(this, R.drawable.actifit_logo));
+        mapView.getOverlays().add(currentPositionMarker);
+
+        if (MODE_LIVE.equals(mode)) {
+            setupLiveMode();
+        } else {
+            setupViewMode();
+        }
+
+        findViewById(R.id.btn_route_back).setOnClickListener(v -> onBackPressed());
+    }
+
+    private void setupLiveMode() {
+        liveControls.setVisibility(View.VISIBLE);
+        viewControls.setVisibility(View.GONE);
+        currentPositionMarker.setVisible(true);
+
+        String actType = getIntent().getStringExtra(EXTRA_ACTIVITY_TYPE);
+        tvActivityLabel.setText(actType != null ? actType : "Recording");
+
+        recordingStartMs = System.currentTimeMillis();
+        startTimer();
+
+        // Register for live waypoint broadcasts
+        waypointReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                double lat = intent.getDoubleExtra(RouteRecordingService.EXTRA_LAT, 0);
+                double lng = intent.getDoubleExtra(RouteRecordingService.EXTRA_LNG, 0);
+                currentDistanceMeters = intent.getDoubleExtra(RouteRecordingService.EXTRA_DISTANCE, 0);
+                addPoint(lat, lng);
+                updateLiveStats(currentDistanceMeters,
+                        intent.getLongExtra(RouteRecordingService.EXTRA_DURATION_MS, 0));
+            }
+        };
+        stoppedReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                long routeId = intent.getLongExtra(RouteRecordingService.EXTRA_ROUTE_ID, -1);
+                double dist = intent.getDoubleExtra(RouteRecordingService.EXTRA_DISTANCE, 0);
+                long durationMs = intent.getLongExtra(RouteRecordingService.EXTRA_DURATION_MS, 0);
+                openSummary(routeId, dist, durationMs);
+            }
+        };
+        LocalBroadcastManager.getInstance(this).registerReceiver(
+                waypointReceiver, new IntentFilter(RouteRecordingService.BROADCAST_WAYPOINT_UPDATE));
+        LocalBroadcastManager.getInstance(this).registerReceiver(
+                stoppedReceiver, new IntentFilter(RouteRecordingService.BROADCAST_RECORDING_STOPPED));
+
+        findViewById(R.id.btn_stop_recording).setOnClickListener(v ->
+                new AlertDialog.Builder(this)
+                        .setTitle("Stop Recording?")
+                        .setMessage("Save and finish this route?")
+                        .setPositiveButton("Stop & Save", (d, w) -> {
+                            Intent stopIntent = new Intent(this, RouteRecordingService.class);
+                            stopIntent.setAction(RouteRecordingService.ACTION_STOP_RECORDING);
+                            startService(stopIntent);
+                        })
+                        .setNegativeButton("Keep Going", null)
+                        .show());
+    }
+
+    private void setupViewMode() {
+        liveControls.setVisibility(View.GONE);
+        viewControls.setVisibility(View.VISIBLE);
+        currentPositionMarker.setVisible(false);
+        tvTimer.setVisibility(View.GONE);
+
+        int dateInt = getIntent().getIntExtra(EXTRA_DATE, 0);
+        long routeId = getIntent().getLongExtra(EXTRA_ROUTE_ID, -1);
+
+        StepsDBHelper db = new StepsDBHelper(this);
+        RouteModel route = null;
+        if (dateInt != 0) {
+            route = db.getRouteForDate(dateInt);
+        }
+
+        if (route == null) {
+            Toast.makeText(this, "Route not found", Toast.LENGTH_SHORT).show();
+            finish();
+            return;
+        }
+
+        tvActivityLabel.setText(route.activityType != null ? route.activityType : "Activity");
+        tvDistance.setText(route.getFormattedDistance());
+        tvDuration.setText(route.getFormattedDuration());
+        tvPace.setText(route.getFormattedPace());
+
+        int stepCount = db.fetchStepCountByDate(String.valueOf(dateInt));
+        tvSteps.setText(stepCount > 0 ? String.format(Locale.getDefault(), "%,d", stepCount) : "--");
+
+        // Draw route from stored waypoints
+        if (route.waypointsJson != null) {
+            List<WaypointModel> waypoints = new Gson().fromJson(route.waypointsJson,
+                    new TypeToken<List<WaypointModel>>() {}.getType());
+            if (waypoints != null) {
+                for (WaypointModel w : waypoints) {
+                    routePoints.add(new GeoPoint(w.lat, w.lng));
+                }
+                routePolyline.setPoints(new ArrayList<>(routePoints));
+                if (!routePoints.isEmpty()) {
+                    fitMapToRoute();
+                }
+            }
+        }
+
+        String sourceLabel = RouteModel.SOURCE_GPS.equals(route.sourceType) ? "GPS"
+                : route.sourceType != null ? route.sourceType : "";
+        if (!sourceLabel.isEmpty()) {
+            tvActivityLabel.setText(tvActivityLabel.getText() + "  •  " + sourceLabel);
+        }
+    }
+
+    private void addPoint(double lat, double lng) {
+        GeoPoint point = new GeoPoint(lat, lng);
+        routePoints.add(point);
+        routePolyline.setPoints(new ArrayList<>(routePoints));
+        currentPositionMarker.setPosition(point);
+        mapView.getController().animateTo(point);
+        mapView.invalidate();
+    }
+
+    private void updateLiveStats(double distanceMeters, long durationMs) {
+        tvDistance.setText(String.format(Locale.getDefault(), "%.2f km", distanceMeters / 1000.0));
+        long min = TimeUnit.MILLISECONDS.toMinutes(durationMs);
+        long sec = TimeUnit.MILLISECONDS.toSeconds(durationMs) % 60;
+        tvDuration.setText(String.format(Locale.getDefault(), "%d:%02d", min, sec));
+        if (distanceMeters > 50) {
+            double secPerKm = (durationMs / 1000.0) / (distanceMeters / 1000.0);
+            long paceMin = (long) secPerKm / 60;
+            long paceSec = (long) secPerKm % 60;
+            tvPace.setText(String.format(Locale.getDefault(), "%d:%02d/km", paceMin, paceSec));
+        }
+    }
+
+    private void fitMapToRoute() {
+        if (routePoints.size() < 2) {
+            mapView.getController().setCenter(routePoints.get(0));
+            return;
+        }
+        BoundingBox box = BoundingBox.fromGeoPointsSafe(routePoints);
+        mapView.post(() -> mapView.zoomToBoundingBox(box, true, 80));
+    }
+
+    private void startTimer() {
+        timerHandler = new Handler(Looper.getMainLooper());
+        timerRunnable = new Runnable() {
+            @Override
+            public void run() {
+                long elapsed = System.currentTimeMillis() - recordingStartMs;
+                long h = TimeUnit.MILLISECONDS.toHours(elapsed);
+                long m = TimeUnit.MILLISECONDS.toMinutes(elapsed) % 60;
+                long s = TimeUnit.MILLISECONDS.toSeconds(elapsed) % 60;
+                if (h > 0) {
+                    tvTimer.setText(String.format(Locale.getDefault(), "%d:%02d:%02d", h, m, s));
+                } else {
+                    tvTimer.setText(String.format(Locale.getDefault(), "%02d:%02d", m, s));
+                }
+                timerHandler.postDelayed(this, 1000);
+            }
+        };
+        timerHandler.post(timerRunnable);
+    }
+
+    private void openSummary(long routeId, double distMeters, long durationMs) {
+        if (timerHandler != null) timerHandler.removeCallbacks(timerRunnable);
+        Intent intent = new Intent(this, RouteMapActivity.class);
+        intent.putExtra(EXTRA_MODE, MODE_VIEW);
+        intent.putExtra(EXTRA_ROUTE_ID, routeId);
+        SimpleDateFormat fmt = new SimpleDateFormat("yyyyMMdd", Locale.ENGLISH);
+        intent.putExtra(EXTRA_DATE, Integer.parseInt(fmt.format(new Date())));
+        startActivity(intent);
+        finish();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        mapView.onResume();
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        mapView.onPause();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        if (timerHandler != null) timerHandler.removeCallbacks(timerRunnable);
+        if (waypointReceiver != null)
+            LocalBroadcastManager.getInstance(this).unregisterReceiver(waypointReceiver);
+        if (stoppedReceiver != null)
+            LocalBroadcastManager.getInstance(this).unregisterReceiver(stoppedReceiver);
+        mapView.onDetach();
+    }
+
+}

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/RouteMapActivity.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/RouteMapActivity.java
@@ -49,6 +49,7 @@ public class RouteMapActivity extends BaseActivity {
     private final List<GeoPoint> routePoints = new ArrayList<>();
 
     private TextView tvDistance, tvDuration, tvPace, tvSteps, tvTimer, tvActivityLabel;
+    private TextView btnZoomIn, btnZoomOut, btnLocate;
     private LinearLayout liveControls, viewControls;
 
     private String mode = MODE_VIEW;
@@ -74,6 +75,7 @@ public class RouteMapActivity extends BaseActivity {
         mapView = findViewById(R.id.route_map_view);
         mapView.setTileSource(TileSourceFactory.MAPNIK);
         mapView.setMultiTouchControls(true);
+        mapView.setMaxZoomLevel(19.0);
         mapView.getController().setZoom(16.0);
 
         tvDistance = findViewById(R.id.tv_route_distance);
@@ -84,6 +86,13 @@ public class RouteMapActivity extends BaseActivity {
         tvActivityLabel = findViewById(R.id.tv_route_activity_label);
         liveControls = findViewById(R.id.live_controls);
         viewControls = findViewById(R.id.view_controls);
+
+        btnZoomIn = findViewById(R.id.btn_zoom_in);
+        btnZoomOut = findViewById(R.id.btn_zoom_out);
+        btnLocate = findViewById(R.id.btn_locate);
+        btnZoomIn.setOnClickListener(v -> mapView.getController().zoomIn());
+        btnZoomOut.setOnClickListener(v -> mapView.getController().zoomOut());
+        btnLocate.setOnClickListener(v -> onLocateTapped());
 
         routePolyline = new Polyline();
         routePolyline.getOutlinePaint().setColor(ContextCompat.getColor(this, R.color.actifitRed));
@@ -107,6 +116,7 @@ public class RouteMapActivity extends BaseActivity {
         liveControls.setVisibility(View.VISIBLE);
         viewControls.setVisibility(View.GONE);
         currentPositionMarker.setVisible(true);
+        tvDuration.setVisibility(View.GONE); // top timer handles elapsed time in live mode
 
         String actType = getIntent().getStringExtra(EXTRA_ACTIVITY_TYPE);
         tvActivityLabel.setText(actType != null ? actType : "Recording");
@@ -158,6 +168,7 @@ public class RouteMapActivity extends BaseActivity {
         viewControls.setVisibility(View.VISIBLE);
         currentPositionMarker.setVisible(false);
         tvTimer.setVisibility(View.GONE);
+        tvDuration.setVisibility(View.VISIBLE);
 
         int dateInt = getIntent().getIntExtra(EXTRA_DATE, 0);
         long routeId = getIntent().getLongExtra(EXTRA_ROUTE_ID, -1);
@@ -179,8 +190,7 @@ public class RouteMapActivity extends BaseActivity {
         tvDuration.setText(route.getFormattedDuration());
         tvPace.setText(route.getFormattedPace());
 
-        int stepCount = db.fetchStepCountByDate(String.valueOf(dateInt));
-        tvSteps.setText(stepCount > 0 ? String.format(Locale.getDefault(), "%,d", stepCount) : "--");
+        tvSteps.setText("--"); // day total ≠ route steps; no per-route step data available
 
         // Draw route from stored waypoints
         if (route.waypointsJson != null) {
@@ -226,13 +236,31 @@ public class RouteMapActivity extends BaseActivity {
         }
     }
 
+    private void onLocateTapped() {
+        if (MODE_LIVE.equals(mode)) {
+            if (!routePoints.isEmpty()) {
+                mapView.getController().animateTo(routePoints.get(routePoints.size() - 1));
+            }
+        } else {
+            if (!routePoints.isEmpty()) {
+                fitMapToRoute();
+            }
+        }
+    }
+
     private void fitMapToRoute() {
         if (routePoints.size() < 2) {
             mapView.getController().setCenter(routePoints.get(0));
+            mapView.getController().setZoom(17.0);
             return;
         }
         BoundingBox box = BoundingBox.fromGeoPointsSafe(routePoints);
-        mapView.post(() -> mapView.zoomToBoundingBox(box, true, 80));
+        mapView.post(() -> {
+            mapView.zoomToBoundingBox(box, true, 80);
+            if (mapView.getZoomLevelDouble() > 19.0) {
+                mapView.getController().setZoom(19.0);
+            }
+        });
     }
 
     private void startTimer() {

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/RouteModel.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/RouteModel.java
@@ -1,0 +1,60 @@
+package io.actifit.fitnesstracker.actifitfitnesstracker;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+public class RouteModel {
+    public long routeId;
+    public int date; // yyyyMMdd
+    public String activityType;
+    public String sourceType; // "GPS", "HealthConnect", "Fitbit"
+    public long startTimeMs;
+    public long endTimeMs;
+    public double distanceMeters;
+    public double elevationGainMeters;
+    public String waypointsJson;
+
+    // Transient — populated after deserialization, not persisted
+    public List<WaypointModel> waypoints;
+
+    public static final String SOURCE_GPS = "GPS";
+    public static final String SOURCE_HEALTH_CONNECT = "HealthConnect";
+    public static final String SOURCE_FITBIT = "Fitbit";
+
+    public RouteModel() {}
+
+    public long getDurationMs() {
+        if (endTimeMs <= startTimeMs) return 0;
+        return endTimeMs - startTimeMs;
+    }
+
+    public String getFormattedDistance() {
+        if (distanceMeters < 1000) {
+            return String.format(Locale.getDefault(), "%.0f m", distanceMeters);
+        }
+        return String.format(Locale.getDefault(), "%.2f km", distanceMeters / 1000.0);
+    }
+
+    public String getFormattedDuration() {
+        long ms = getDurationMs();
+        long hours = TimeUnit.MILLISECONDS.toHours(ms);
+        long minutes = TimeUnit.MILLISECONDS.toMinutes(ms) % 60;
+        long seconds = TimeUnit.MILLISECONDS.toSeconds(ms) % 60;
+        if (hours > 0) {
+            return String.format(Locale.getDefault(), "%d:%02d:%02d", hours, minutes, seconds);
+        }
+        return String.format(Locale.getDefault(), "%d:%02d", minutes, seconds);
+    }
+
+    /** Returns avg pace as min/km string, e.g. "7:07/km". Returns "" if no movement. */
+    public String getFormattedPace() {
+        long durationSec = TimeUnit.MILLISECONDS.toSeconds(getDurationMs());
+        double distKm = distanceMeters / 1000.0;
+        if (distKm < 0.01 || durationSec == 0) return "--";
+        double secPerKm = durationSec / distKm;
+        long paceMin = (long) secPerKm / 60;
+        long paceSec = (long) secPerKm % 60;
+        return String.format(Locale.getDefault(), "%d:%02d/km", paceMin, paceSec);
+    }
+}

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/RouteRecordingService.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/RouteRecordingService.java
@@ -1,0 +1,232 @@
+package io.actifit.fitnesstracker.actifitfitnesstracker;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.Intent;
+import android.location.Location;
+import android.os.Build;
+import android.os.IBinder;
+import android.os.Looper;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.app.NotificationCompat;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
+import com.google.android.gms.location.FusedLocationProviderClient;
+import com.google.android.gms.location.LocationCallback;
+import com.google.android.gms.location.LocationRequest;
+import com.google.android.gms.location.LocationResult;
+import com.google.android.gms.location.LocationServices;
+import com.google.android.gms.location.Priority;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+public class RouteRecordingService extends Service {
+
+    private static final String TAG = "RouteRecordingService";
+    private static final String CHANNEL_ID = "route_recording";
+    private static final int NOTIFICATION_ID = 2001;
+
+    public static final String ACTION_STOP_RECORDING = "io.actifit.route.STOP";
+    public static final String BROADCAST_WAYPOINT_UPDATE = "io.actifit.route.WAYPOINT_UPDATE";
+    public static final String BROADCAST_RECORDING_STOPPED = "io.actifit.route.STOPPED";
+
+    public static final String EXTRA_ACTIVITY_TYPE = "activityType";
+    public static final String EXTRA_ROUTE_ID = "routeId";
+    public static final String EXTRA_LAT = "lat";
+    public static final String EXTRA_LNG = "lng";
+    public static final String EXTRA_DISTANCE = "distance";
+    public static final String EXTRA_DURATION_MS = "durationMs";
+
+    private FusedLocationProviderClient fusedLocationClient;
+    private LocationCallback locationCallback;
+    private final List<WaypointModel> waypoints = new ArrayList<>();
+    private String activityType = "Walking";
+    private long startTimeMs;
+    private double totalDistanceMeters = 0;
+    private Location lastLocation;
+
+    public static boolean isRunning = false;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        createNotificationChannel();
+        fusedLocationClient = LocationServices.getFusedLocationProviderClient(this);
+
+        locationCallback = new LocationCallback() {
+            @Override
+            public void onLocationResult(@NonNull LocationResult result) {
+                for (Location location : result.getLocations()) {
+                    onNewLocation(location);
+                }
+            }
+        };
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        if (intent != null) {
+            if (ACTION_STOP_RECORDING.equals(intent.getAction())) {
+                stopRecording();
+                return START_NOT_STICKY;
+            }
+            activityType = intent.getStringExtra(EXTRA_ACTIVITY_TYPE);
+            if (activityType == null) activityType = "Walking";
+        }
+        startRecording();
+        return START_STICKY;
+    }
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        isRunning = false;
+        fusedLocationClient.removeLocationUpdates(locationCallback);
+    }
+
+    private void startRecording() {
+        isRunning = true;
+        startTimeMs = System.currentTimeMillis();
+        waypoints.clear();
+        totalDistanceMeters = 0;
+        lastLocation = null;
+
+        startForeground(NOTIFICATION_ID, buildNotification("0.00 km", "00:00"));
+
+        LocationRequest locationRequest = new LocationRequest.Builder(
+                Priority.PRIORITY_HIGH_ACCURACY, 3000)
+                .setMinUpdateIntervalMillis(1000)
+                .build();
+
+        try {
+            fusedLocationClient.requestLocationUpdates(locationRequest, locationCallback,
+                    Looper.getMainLooper());
+        } catch (SecurityException e) {
+            Log.e(TAG, "Location permission missing", e);
+            stopSelf();
+        }
+    }
+
+    private void onNewLocation(Location location) {
+        if (location == null) return;
+
+        WaypointModel waypoint = new WaypointModel(
+                location.getLatitude(),
+                location.getLongitude(),
+                location.hasAltitude() ? location.getAltitude() : 0,
+                location.getTime(),
+                location.getAccuracy(),
+                location.hasSpeed() ? location.getSpeed() : 0
+        );
+        waypoints.add(waypoint);
+
+        if (lastLocation != null) {
+            totalDistanceMeters += lastLocation.distanceTo(location);
+        }
+        lastLocation = location;
+
+        long durationMs = System.currentTimeMillis() - startTimeMs;
+        updateNotification(totalDistanceMeters, durationMs);
+
+        Intent broadcast = new Intent(BROADCAST_WAYPOINT_UPDATE);
+        broadcast.putExtra(EXTRA_LAT, location.getLatitude());
+        broadcast.putExtra(EXTRA_LNG, location.getLongitude());
+        broadcast.putExtra(EXTRA_DISTANCE, totalDistanceMeters);
+        broadcast.putExtra(EXTRA_DURATION_MS, durationMs);
+        LocalBroadcastManager.getInstance(this).sendBroadcast(broadcast);
+    }
+
+    private void stopRecording() {
+        fusedLocationClient.removeLocationUpdates(locationCallback);
+        isRunning = false;
+
+        long endTimeMs = System.currentTimeMillis();
+        String waypointsJson = new Gson().toJson(waypoints,
+                new TypeToken<List<WaypointModel>>() {}.getType());
+
+        SimpleDateFormat fmt = new SimpleDateFormat("yyyyMMdd", Locale.ENGLISH);
+        int dateInt = Integer.parseInt(fmt.format(new Date(startTimeMs)));
+
+        RouteModel route = new RouteModel();
+        route.date = dateInt;
+        route.activityType = activityType;
+        route.sourceType = RouteModel.SOURCE_GPS;
+        route.startTimeMs = startTimeMs;
+        route.endTimeMs = endTimeMs;
+        route.distanceMeters = totalDistanceMeters;
+        route.waypointsJson = waypointsJson;
+
+        StepsDBHelper db = new StepsDBHelper(this);
+        long routeId = db.insertRoute(route);
+
+        Intent broadcast = new Intent(BROADCAST_RECORDING_STOPPED);
+        broadcast.putExtra(EXTRA_ROUTE_ID, routeId);
+        broadcast.putExtra(EXTRA_DISTANCE, totalDistanceMeters);
+        broadcast.putExtra(EXTRA_DURATION_MS, endTimeMs - startTimeMs);
+        LocalBroadcastManager.getInstance(this).sendBroadcast(broadcast);
+
+        stopForeground(true);
+        stopSelf();
+    }
+
+    private void updateNotification(double distanceMeters, long durationMs) {
+        String distStr = String.format(Locale.getDefault(), "%.2f km", distanceMeters / 1000.0);
+        long min = TimeUnit.MILLISECONDS.toMinutes(durationMs);
+        long sec = TimeUnit.MILLISECONDS.toSeconds(durationMs) % 60;
+        String timeStr = String.format(Locale.getDefault(), "%02d:%02d", min, sec);
+        NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+        if (nm != null) nm.notify(NOTIFICATION_ID, buildNotification(distStr, timeStr));
+    }
+
+    private Notification buildNotification(String distStr, String timeStr) {
+        Intent stopIntent = new Intent(this, RouteRecordingService.class);
+        stopIntent.setAction(ACTION_STOP_RECORDING);
+        int flags = PendingIntent.FLAG_UPDATE_CURRENT;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) flags |= PendingIntent.FLAG_IMMUTABLE;
+        PendingIntent stopPending = PendingIntent.getService(this, 0, stopIntent, flags);
+
+        Intent openIntent = new Intent(this, RouteMapActivity.class);
+        openIntent.putExtra(RouteMapActivity.EXTRA_MODE, RouteMapActivity.MODE_LIVE);
+        openIntent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        PendingIntent openPending = PendingIntent.getActivity(this, 0, openIntent, flags);
+
+        return new NotificationCompat.Builder(this, CHANNEL_ID)
+                .setSmallIcon(R.drawable.actifit_logo)
+                .setContentTitle("Recording: " + activityType)
+                .setContentText(distStr + "  •  " + timeStr)
+                .setOngoing(true)
+                .setContentIntent(openPending)
+                .addAction(R.drawable.actifit_logo, "Stop", stopPending)
+                .build();
+    }
+
+    private void createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel channel = new NotificationChannel(
+                    CHANNEL_ID, "Route Recording", NotificationManager.IMPORTANCE_LOW);
+            channel.setDescription("Shows active route recording status");
+            channel.setShowBadge(false);
+            NotificationManager nm = getSystemService(NotificationManager.class);
+            if (nm != null) nm.createNotificationChannel(channel);
+        }
+    }
+}

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/StepHistoryActivity.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/StepHistoryActivity.java
@@ -104,10 +104,9 @@ public class StepHistoryActivity extends BaseActivity { // Assuming BaseActivity
             }
 
             ArrayList<DateStepsModel> stepsList = null;
+            StepsDBHelper stepsDBHelper = null;
             try {
-                // Load steps from Database (ensure StepsDBHelper is thread-safe or create new instance)
-                // Using Activity context for DB helper is generally acceptable here.
-                StepsDBHelper stepsDBHelper = new StepsDBHelper(activity);
+                stepsDBHelper = new StepsDBHelper(activity);
                 stepsList = stepsDBHelper.readStepsEntries();
             } catch (Exception e) {
                 Log.e(MainActivity.TAG, "Error loading steps from DB", e);
@@ -122,13 +121,16 @@ public class StepHistoryActivity extends BaseActivity { // Assuming BaseActivity
                 SimpleDateFormat dateFormOut = new SimpleDateFormat("MM/dd/yyyy", Locale.getDefault());
 
                 for (DateStepsModel stepEntry : stepsList) {
-                    if (isCancelled()) return null; // Check for cancellation
+                    if (isCancelled()) return null;
                     try {
                         Date feedingDate = dateFormIn.parse(stepEntry.mDate);
                         String dateDisplay = dateFormOut.format(feedingDate);
-                        // Create initial entry without post link data
                         DateStepsModel newEntry = new DateStepsModel(dateDisplay, stepEntry.mStepCount, stepEntry.mtrackingDevice);
-                        // relevantPostChecked and hasRelevantPost will be false by default
+                        int rawDate = Integer.parseInt(stepEntry.mDate);
+                        newEntry.rawDate = rawDate;
+                        if (stepsDBHelper != null) {
+                            newEntry.hasRoute = stepsDBHelper.hasRouteForDate(rawDate);
+                        }
                         initialStepFinalList.add(newEntry);
                     } catch (ParseException txtEx) {
                         Log.d(MainActivity.TAG, "Error parsing date for step entry: " + stepEntry.mDate, txtEx);

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/StepsDBHelper.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/StepsDBHelper.java
@@ -21,7 +21,7 @@ import java.util.Locale;
 import static java.lang.String.format;
 
 public class StepsDBHelper extends SQLiteOpenHelper {
-    private static final int DATABASE_VERSION = 3;
+    private static final int DATABASE_VERSION = 4;
     private static final String DATABASE_NAME = "ActifitFitness";
     public static final String TABLE_STEPS_SUMMARY = "ActifitFitness";
     private static final String CREATION_DATE = "creationdate";//Date format is yyyyMMdd
@@ -33,6 +33,17 @@ public class StepsDBHelper extends SQLiteOpenHelper {
     private static final String TIME_SLOT = "timeSlot";
     private static final String ACTIVITY_COUNT = "activityCount";
     public static final int MAX_SLOTS_PER_DAY = 100;
+
+    public static final String TABLE_ACTIVITY_ROUTES = "ActivityRoutes";
+    private static final String ROUTE_ID = "routeId";
+    private static final String ROUTE_DATE = "date";
+    private static final String ROUTE_ACTIVITY_TYPE = "activityType";
+    private static final String ROUTE_SOURCE_TYPE = "sourceType";
+    private static final String ROUTE_START_TIME = "startTime";
+    private static final String ROUTE_END_TIME = "endTime";
+    private static final String ROUTE_DISTANCE = "distanceMeters";
+    private static final String ROUTE_ELEVATION = "elevationGainMeters";
+    private static final String ROUTE_WAYPOINTS = "waypointsJson";
 
     public static final String DEVICE_SENSORS = "Device Sensors";
     public static final String FITBIT = "Fitbit";
@@ -56,6 +67,18 @@ public class StepsDBHelper extends SQLiteOpenHelper {
             TIME_SLOT + " INTEGER, " +
             ACTIVITY_COUNT+" INTEGER )";
 
+    private static final String CREATE_TABLE_ACTIVITY_ROUTES = "CREATE TABLE IF NOT EXISTS "
+            + TABLE_ACTIVITY_ROUTES + "("
+            + ROUTE_ID + " INTEGER PRIMARY KEY AUTOINCREMENT, "
+            + ROUTE_DATE + " INTEGER NOT NULL, "
+            + ROUTE_ACTIVITY_TYPE + " TEXT, "
+            + ROUTE_SOURCE_TYPE + " TEXT, "
+            + ROUTE_START_TIME + " INTEGER, "
+            + ROUTE_END_TIME + " INTEGER, "
+            + ROUTE_DISTANCE + " REAL, "
+            + ROUTE_ELEVATION + " REAL, "
+            + ROUTE_WAYPOINTS + " TEXT)";
+
 
     StepsDBHelper(Context context) {
         super(context, DATABASE_NAME, null, DATABASE_VERSION);
@@ -65,20 +88,16 @@ public class StepsDBHelper extends SQLiteOpenHelper {
     }
 
     @Override
-    public void onUpgrade(SQLiteDatabase db,int oldVersion, int newVersion ){
-        switch(oldVersion) {
-
-            // If the existing version is before v1 (on which we added the new field)
-            case 2: db.execSQL(CREATE_TABLE_ACTIVITY_DETAILS);
-                break;
-
-            // If the existing version is before v1 (on which we added the new field)
-            case 1: db.execSQL("ALTER TABLE "+TABLE_STEPS_SUMMARY
-                    +" ADD COLUMN "+TRACKING_DEVICE+" TEXT");
-                break;
-            default:
-                throw new IllegalStateException(
-                        "onUpgrade() with unknown oldVersion " + oldVersion);
+    public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+        if (oldVersion < 2) {
+            db.execSQL("ALTER TABLE " + TABLE_STEPS_SUMMARY
+                    + " ADD COLUMN " + TRACKING_DEVICE + " TEXT");
+        }
+        if (oldVersion < 3) {
+            db.execSQL(CREATE_TABLE_ACTIVITY_DETAILS);
+        }
+        if (oldVersion < 4) {
+            db.execSQL(CREATE_TABLE_ACTIVITY_ROUTES);
         }
     }
 
@@ -86,6 +105,7 @@ public class StepsDBHelper extends SQLiteOpenHelper {
     public void onCreate(SQLiteDatabase db) {
         db.execSQL(CREATE_TABLE_ACTIFIT);
         db.execSQL(CREATE_TABLE_ACTIVITY_DETAILS);
+        db.execSQL(CREATE_TABLE_ACTIVITY_ROUTES);
     }
 
     public int recordDetailedSteps(int incrementVal) {
@@ -489,6 +509,77 @@ public class StepsDBHelper extends SQLiteOpenHelper {
         if (dbInstance.isOpen()){
             dbInstance.close();
         }
+    }
+
+    // ── Route CRUD ──────────────────────────────────────────────────────────
+
+    public long insertRoute(RouteModel route) {
+        ContentValues values = new ContentValues();
+        values.put(ROUTE_DATE, route.date);
+        values.put(ROUTE_ACTIVITY_TYPE, route.activityType);
+        values.put(ROUTE_SOURCE_TYPE, route.sourceType);
+        values.put(ROUTE_START_TIME, route.startTimeMs);
+        values.put(ROUTE_END_TIME, route.endTimeMs);
+        values.put(ROUTE_DISTANCE, route.distanceMeters);
+        values.put(ROUTE_ELEVATION, route.elevationGainMeters);
+        values.put(ROUTE_WAYPOINTS, route.waypointsJson);
+        return dbInstance.insert(TABLE_ACTIVITY_ROUTES, null, values);
+    }
+
+    @SuppressLint("Range")
+    public RouteModel getRouteForDate(int date) {
+        Cursor cursor = dbInstance.query(TABLE_ACTIVITY_ROUTES, null,
+                ROUTE_DATE + "=?", new String[]{String.valueOf(date)},
+                null, null, ROUTE_START_TIME + " DESC", "1");
+        if (cursor != null && cursor.moveToFirst()) {
+            RouteModel route = cursorToRoute(cursor);
+            cursor.close();
+            return route;
+        }
+        if (cursor != null) cursor.close();
+        return null;
+    }
+
+    @SuppressLint("Range")
+    public RouteModel getMostRecentRoute() {
+        Cursor cursor = dbInstance.query(TABLE_ACTIVITY_ROUTES, null,
+                null, null, null, null, ROUTE_START_TIME + " DESC", "1");
+        if (cursor != null && cursor.moveToFirst()) {
+            RouteModel route = cursorToRoute(cursor);
+            cursor.close();
+            return route;
+        }
+        if (cursor != null) cursor.close();
+        return null;
+    }
+
+    public boolean hasRouteForDate(int date) {
+        Cursor cursor = dbInstance.query(TABLE_ACTIVITY_ROUTES,
+                new String[]{ROUTE_ID}, ROUTE_DATE + "=?",
+                new String[]{String.valueOf(date)}, null, null, null, "1");
+        boolean has = cursor != null && cursor.moveToFirst();
+        if (cursor != null) cursor.close();
+        return has;
+    }
+
+    public void deleteRoute(long routeId) {
+        dbInstance.delete(TABLE_ACTIVITY_ROUTES, ROUTE_ID + "=?",
+                new String[]{String.valueOf(routeId)});
+    }
+
+    @SuppressLint("Range")
+    private RouteModel cursorToRoute(Cursor cursor) {
+        RouteModel route = new RouteModel();
+        route.routeId = cursor.getLong(cursor.getColumnIndex(ROUTE_ID));
+        route.date = cursor.getInt(cursor.getColumnIndex(ROUTE_DATE));
+        route.activityType = cursor.getString(cursor.getColumnIndex(ROUTE_ACTIVITY_TYPE));
+        route.sourceType = cursor.getString(cursor.getColumnIndex(ROUTE_SOURCE_TYPE));
+        route.startTimeMs = cursor.getLong(cursor.getColumnIndex(ROUTE_START_TIME));
+        route.endTimeMs = cursor.getLong(cursor.getColumnIndex(ROUTE_END_TIME));
+        route.distanceMeters = cursor.getDouble(cursor.getColumnIndex(ROUTE_DISTANCE));
+        route.elevationGainMeters = cursor.getDouble(cursor.getColumnIndex(ROUTE_ELEVATION));
+        route.waypointsJson = cursor.getString(cursor.getColumnIndex(ROUTE_WAYPOINTS));
+        return route;
     }
 
 }

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/WaypointModel.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/WaypointModel.java
@@ -1,0 +1,22 @@
+package io.actifit.fitnesstracker.actifitfitnesstracker;
+
+public class WaypointModel {
+    public double lat;
+    public double lng;
+    public double altitudeMeters;
+    public long timestampMs;
+    public float accuracy;
+    public float speedMps;
+
+    public WaypointModel() {}
+
+    public WaypointModel(double lat, double lng, double altitudeMeters,
+                         long timestampMs, float accuracy, float speedMps) {
+        this.lat = lat;
+        this.lng = lng;
+        this.altitudeMeters = altitudeMeters;
+        this.timestampMs = timestampMs;
+        this.accuracy = accuracy;
+        this.speedMps = speedMps;
+    }
+}

--- a/app/src/main/res/layout/activity_history_single_entry.xml
+++ b/app/src/main/res/layout/activity_history_single_entry.xml
@@ -58,4 +58,19 @@
         android:layout_marginStart="10dp"
         />
 
+    <TextView
+        android:id="@+id/btn_view_route"
+        android:layout_width="40sp"
+        android:layout_height="40sp"
+        android:text="&#xf3c5;"
+        android:textColor="@color/actifitRed"
+        android:layout_marginTop="10dp"
+        android:layout_marginStart="6dp"
+        android:textSize="24sp"
+        android:gravity="center"
+        android:visibility="gone"
+        android:fontFamily="@font/font_awesome_6_solid"
+        tools:ignore="HardcodedText"
+        xmlns:tools="http://schemas.android.com/tools" />
+
 </LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -309,10 +309,9 @@
                             android:layout_width="28dp"
                             android:layout_height="28dp"
                             android:contentDescription="Health Connect"
-                            android:src="@mipmap/health_connect_logo"
+                            android:src="@mipmap/health_connect"
                             android:scaleType="fitCenter"
                             android:padding="2dp"
-                            android:background="@drawable/health_connect_indicator_bg"
                             android:visibility="gone" />
                     </LinearLayout>
 
@@ -383,7 +382,7 @@
                                 android:layout_width="25dp"
                                 android:layout_height="25dp"
                                 android:contentDescription="Health Connect Logo"
-                                android:src="@mipmap/health_connect_logo" />
+                                android:src="@mipmap/health_connect" />
 
                             <TextView
                                 android:id="@+id/sync_health_connect"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -198,11 +198,17 @@
         android:layout_height="wrap_content"
         android:visibility="gone" />
 
-    <!-- Scrollable Content -->
-    <ScrollView
+    <!-- Scrollable Content + FAB overlay -->
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1"
+        android:layout_weight="1">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingBottom="72dp"
+        android:clipToPadding="false"
         android:fillViewport="true"
         android:overScrollMode="never">
 
@@ -994,36 +1000,6 @@
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 
-            <!-- Quick Actions Row -->
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:layout_marginBottom="@dimen/spacing_md"
-                android:weightSum="2">
-
-                <com.google.android.material.button.MaterialButton
-                    style="@style/AppTheme.ActifitButton"
-                    android:id="@+id/btn_post_steemit"
-                    android:layout_width="0dp"
-                    android:layout_height="@dimen/button_height"
-                    android:layout_weight="1"
-                    android:layout_marginEnd="@dimen/spacing_sm"
-                    android:text="@string/post_to_steem_btn_txt"
-                    android:textSize="@dimen/text_body" />
-
-                <com.google.android.material.button.MaterialButton
-                    style="@style/AppTheme.ActifitButton"
-                    android:id="@+id/btn_waves"
-                    android:layout_width="0dp"
-                    android:layout_height="@dimen/button_height"
-                    android:layout_weight="1"
-                    android:layout_marginStart="@dimen/spacing_sm"
-                    android:text="\uf086"
-                    android:textSize="@dimen/text_body"
-                    android:fontFamily="@font/font_awesome_6_solid" />
-            </LinearLayout>
-
             <!-- Earnings & Gadgets Card -->
             <com.google.android.material.card.MaterialCardView
                 android:id="@+id/earnings_gadgets_card"
@@ -1317,11 +1293,12 @@
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 
-            <!-- Rewards Row -->
+            <!-- Rewards + Discussions Row -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"
+                android:weightSum="4"
                 android:layout_marginBottom="@dimen/spacing_md">
 
                 <com.google.android.material.button.MaterialButton
@@ -1354,9 +1331,22 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:layout_marginStart="@dimen/spacing_xs"
+                    android:layout_marginEnd="@dimen/spacing_xs"
                     android:textSize="20sp"
                     android:fontFamily="@font/font_awesome_6_solid"
                     android:text="\uf201"
+                    tools:ignore="HardcodedText" />
+
+                <com.google.android.material.button.MaterialButton
+                    style="@style/AppTheme.ActifitButton"
+                    android:id="@+id/btn_waves"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginStart="@dimen/spacing_xs"
+                    android:textSize="20sp"
+                    android:fontFamily="@font/font_awesome_6_solid"
+                    android:text="\uf086"
                     tools:ignore="HardcodedText" />
             </LinearLayout>
 
@@ -1526,6 +1516,21 @@
 
         </LinearLayout>
     </ScrollView>
+
+        <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
+            android:id="@+id/btn_post_steemit"
+            style="@style/Widget.MaterialComponents.ExtendedFloatingActionButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|center_horizontal"
+            android:layout_marginBottom="8dp"
+            android:text="@string/post_to_steem_btn_txt"
+            app:icon="@drawable/ic_edit_black_24dp"
+            app:iconTint="@color/colorWhite"
+            app:backgroundTint="@color/actifitRed"
+            app:elevation="6dp" />
+
+    </FrameLayout>
 
     <!-- Footer Menu -->
     <include

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -894,6 +894,106 @@
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 
+            <!-- Route Tracking Card -->
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/route_tracking_card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/spacing_md"
+                app:cardCornerRadius="@dimen/card_corner_radius"
+                app:cardElevation="@dimen/card_elevation"
+                app:cardBackgroundColor="@color/md_theme_cardBackground">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="@dimen/spacing_md">
+
+                    <!-- Card header -->
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical"
+                        android:paddingBottom="@dimen/spacing_xs">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:fontFamily="@font/font_awesome_6_solid"
+                            android:textColor="@color/actifitRed"
+                            android:textSize="14sp"
+                            android:text="&#xf279;"
+                            tools:ignore="HardcodedText" />
+
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:paddingStart="8dp"
+                            android:text="Route Tracking"
+                            android:textSize="14sp"
+                            android:textStyle="bold"
+                            android:textColor="@color/md_theme_onSurface"
+                            tools:ignore="HardcodedText" />
+                    </LinearLayout>
+
+                    <!-- Last route summary (hidden when no routes exist) -->
+                    <LinearLayout
+                        android:id="@+id/last_route_summary"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical"
+                        android:paddingBottom="@dimen/spacing_xs"
+                        android:visibility="gone">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:fontFamily="@font/font_awesome_6_solid"
+                            android:textColor="@color/md_theme_secondary"
+                            android:textSize="11sp"
+                            android:text="&#xf017;"
+                            android:paddingEnd="4dp"
+                            tools:ignore="HardcodedText" />
+
+                        <TextView
+                            android:id="@+id/tv_last_route_info"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:textSize="12sp"
+                            android:textColor="@color/md_theme_secondary"
+                            tools:ignore="HardcodedText" />
+
+                        <TextView
+                            android:id="@+id/tv_last_route_view"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:textSize="12sp"
+                            android:textColor="@color/actifitRed"
+                            android:paddingStart="@dimen/spacing_xs"
+                            android:text="View &#xf054;"
+                            android:background="?attr/selectableItemBackground"
+                            android:clickable="true"
+                            android:focusable="true"
+                            tools:ignore="HardcodedText" />
+                    </LinearLayout>
+
+                    <!-- Start Recording button -->
+                    <com.google.android.material.button.MaterialButton
+                        style="@style/AppTheme.ActifitButton"
+                        android:id="@+id/btn_start_route_recording"
+                        android:layout_width="match_parent"
+                        android:layout_height="@dimen/button_height"
+                        android:text="&#x25b6;  Start Recording"
+                        tools:ignore="HardcodedText" />
+
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
             <!-- Quick Actions Row -->
             <LinearLayout
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_route_map.xml
+++ b/app/src/main/res/layout/activity_route_map.xml
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <!-- Full-screen map -->
+    <org.osmdroid.views.MapView
+        android:id="@+id/route_map_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <!-- Top bar: back + activity label + live timer -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:padding="12dp"
+        android:background="#88000000">
+
+        <TextView
+            android:id="@+id/btn_route_back"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:text="&#xf060;"
+            android:textColor="@color/colorWhite"
+            android:textSize="18sp"
+            android:gravity="center"
+            android:fontFamily="@font/font_awesome_6_solid"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:clickable="true"
+            android:focusable="true"
+            tools:ignore="HardcodedText" />
+
+        <TextView
+            android:id="@+id/tv_route_activity_label"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:paddingStart="8dp"
+            android:textColor="@color/colorWhite"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            android:text="Route"
+            tools:ignore="HardcodedText" />
+
+        <TextView
+            android:id="@+id/tv_route_timer"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/actifitRed"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            android:text="00:00"
+            tools:ignore="HardcodedText" />
+    </LinearLayout>
+
+    <!-- Bottom panel: stats + controls -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:orientation="vertical"
+        android:background="#EE1A1A1A"
+        android:paddingTop="12dp"
+        android:paddingBottom="16dp"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
+
+        <!-- Stats row -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:weightSum="3"
+            android:paddingBottom="12dp">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:gravity="center">
+
+                <TextView
+                    android:id="@+id/tv_route_distance"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="0.00 km"
+                    android:textColor="@color/colorWhite"
+                    android:textSize="18sp"
+                    android:textStyle="bold"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Distance"
+                    android:textColor="#AAFFFFFF"
+                    android:textSize="11sp"
+                    tools:ignore="HardcodedText" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:gravity="center">
+
+                <TextView
+                    android:id="@+id/tv_route_pace"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="--"
+                    android:textColor="@color/colorWhite"
+                    android:textSize="18sp"
+                    android:textStyle="bold"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Avg Pace"
+                    android:textColor="#AAFFFFFF"
+                    android:textSize="11sp"
+                    tools:ignore="HardcodedText" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:gravity="center">
+
+                <TextView
+                    android:id="@+id/tv_route_steps"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="--"
+                    android:textColor="@color/colorWhite"
+                    android:textSize="18sp"
+                    android:textStyle="bold"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Steps"
+                    android:textColor="#AAFFFFFF"
+                    android:textSize="11sp"
+                    tools:ignore="HardcodedText" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <!-- Duration row (below stats) -->
+        <TextView
+            android:id="@+id/tv_route_duration"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="0:00"
+            android:textColor="#AAFFFFFF"
+            android:textSize="13sp"
+            android:paddingBottom="8dp"
+            tools:ignore="HardcodedText" />
+
+        <!-- LIVE controls -->
+        <LinearLayout
+            android:id="@+id/live_controls"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center"
+            android:visibility="gone">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_stop_recording"
+                style="@style/AppTheme.ActifitButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="&#xf04d;  Stop &amp; Save"
+                android:fontFamily="@font/font_awesome_6_solid"
+                tools:ignore="HardcodedText" />
+        </LinearLayout>
+
+        <!-- VIEW controls -->
+        <LinearLayout
+            android:id="@+id/view_controls"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center"
+            android:visibility="gone">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_share_route"
+                style="@style/AppTheme.ActifitButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="&#xf1e0;  Share"
+                android:fontFamily="@font/font_awesome_6_solid"
+                tools:ignore="HardcodedText" />
+        </LinearLayout>
+
+    </LinearLayout>
+
+</FrameLayout>

--- a/app/src/main/res/layout/activity_route_map.xml
+++ b/app/src/main/res/layout/activity_route_map.xml
@@ -58,6 +58,70 @@
             tools:ignore="HardcodedText" />
     </LinearLayout>
 
+    <!-- Floating map controls (right side, vertically centered) -->
+    <LinearLayout
+        android:id="@+id/map_controls"
+        android:layout_width="40dp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end|center_vertical"
+        android:layout_marginEnd="8dp"
+        android:orientation="vertical"
+        android:background="#CC222222"
+        android:paddingTop="4dp"
+        android:paddingBottom="4dp">
+
+        <TextView
+            android:id="@+id/btn_zoom_in"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:text="+"
+            android:textColor="@color/colorWhite"
+            android:textSize="22sp"
+            android:gravity="center"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:clickable="true"
+            android:focusable="true"
+            tools:ignore="HardcodedText" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="#44FFFFFF" />
+
+        <TextView
+            android:id="@+id/btn_zoom_out"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:text="&#x2212;"
+            android:textColor="@color/colorWhite"
+            android:textSize="22sp"
+            android:gravity="center"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:clickable="true"
+            android:focusable="true"
+            tools:ignore="HardcodedText" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="#44FFFFFF" />
+
+        <TextView
+            android:id="@+id/btn_locate"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:text="&#xf05b;"
+            android:fontFamily="@font/font_awesome_6_solid"
+            android:textColor="@color/colorWhite"
+            android:textSize="16sp"
+            android:gravity="center"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:clickable="true"
+            android:focusable="true"
+            tools:ignore="HardcodedText" />
+
+    </LinearLayout>
+
     <!-- Bottom panel: stats + controls -->
     <LinearLayout
         android:layout_width="match_parent"
@@ -183,8 +247,7 @@
                 style="@style/AppTheme.ActifitButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="&#xf04d;  Stop &amp; Save"
-                android:fontFamily="@font/font_awesome_6_solid"
+                android:text="Stop &amp; Save"
                 tools:ignore="HardcodedText" />
         </LinearLayout>
 
@@ -202,8 +265,7 @@
                 style="@style/AppTheme.ActifitButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="&#xf1e0;  Share"
-                android:fontFamily="@font/font_awesome_6_solid"
+                android:text="Share Route"
                 tools:ignore="HardcodedText" />
         </LinearLayout>
 

--- a/app/src/main/res/layout/bottom_sheet_activity_picker.xml
+++ b/app/src/main/res/layout/bottom_sheet_activity_picker.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="@dimen/spacing_md">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Select Activity Type"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        android:textColor="@color/md_theme_onSurface"
+        android:paddingBottom="@dimen/spacing_sm"
+        tools:ignore="HardcodedText" />
+
+    <com.google.android.material.chip.ChipGroup
+        android:id="@+id/activity_type_chip_group"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:singleSelection="true"
+        app:selectionRequired="true" />
+
+</LinearLayout>


### PR DESCRIPTION
## Summary

- **Route Map Tracking (Phase 1)**: GPS-based route recording via foreground service (FusedLocationProviderClient), live OSMDroid map with red polyline, activity type picker bottom sheet, VIEW mode for historical routes, route badge in step history screen, route tracking card on dashboard
- **Dashboard layout redesign**: Post & Earn promoted to persistent Extended FAB (bottom-centre), Discussions merged into compact rewards row (now 4 icons), Quick Actions row removed, news carousel modernised with MaterialCardView, earnings & gadgets panel redesigned
- **Route map bug fixes**: Stop/Share button text rendering, VIEW mode steps showing day total, blank tiles on short routes (zoom capped at 19), duplicate live timer removed, zoom in/out/locate map controls added
- **Health Connect icon**: Removed white background from HC icons in steps dashboard by switching from adaptive icon mipmap to foreground-only asset

## New files
- `RouteRecordingService.java` — foreground location service
- `RouteMapActivity.java` + `activity_route_map.xml` — live/view map screen
- `RouteModel.java`, `WaypointModel.java` — data models
- `bottom_sheet_activity_picker.xml` — activity type picker

## Modified files
- `StepsDBHelper.java` — ActivityRoutes table (DB v4), CRUD methods, fixed onUpgrade chain
- `MainActivity.java` — route card wiring, permission launcher, last route summary
- `StepHistoryActivity.java` — route badge per date
- `ActivityEntryAdapter.java` — View Route button
- `activity_main.xml`, `activity_history_single_entry.xml`, `DateStepsModel.java`
- `app/build.gradle`, `AndroidManifest.xml` — OSMDroid + play-services-location deps, location permissions, service/activity declarations

## Test plan
- [ ] Grant location permission → Start Recording → select activity type → walk path → Stop & Save → polyline and stats shown
- [ ] Deny location permission → tap Start Recording → rationale shown, no crash
- [ ] History screen → route badge visible only on days with a recorded route → tap View Route → correct polyline
- [ ] Post & Earn FAB visible at bottom while scrolling dashboard; taps through to PostSteemitActivity
- [ ] Rewards row shows 4 icon buttons (🎁 · 👥 · 📈 · 💬), all functional
- [ ] Health Connect active → no white box around HC icon in steps card

🤖 Generated with [Claude Code](https://claude.ai/claude-code)