### PR TITLE
Translate DHF vote prompt and Hive transactions strings

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,9 @@ plugins{
 
 def keystorePropertiesFile = rootProject.file("keystore.properties")
 def keystoreProperties = new Properties()
-keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
 
 final def markwonVersion = '4.6.2'
 

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/AiService.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/AiService.java
@@ -25,7 +25,7 @@ class NetworkClient {
 public class AiService {
 
 
-    private static final String API_KEY = BuildConfig.GEMINI_API_KEY; // **REPLACE WITH YOUR ACTUAL API KEY!**
+    private static final String API_KEY = BuildConfig.GEMINI_API_KEY;
     //private static final String API_URL = "https://generativelanguage.googleapis.com/v1/models/gemini-2.5-flash:generateContent?key=" + API_KEY;
     private static final String API_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-latest:generateContent";
     //private final OkHttpClient client = new OkHttpClient();

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/AiService.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/AiService.java
@@ -360,20 +360,47 @@ public class AiService {
         });
     }
 
+    public static class ContentBlockedException extends Exception {
+        public ContentBlockedException(String message) {
+            super(message);
+        }
+    }
+
     private String parseSimpleTextResponse(String responseBody) throws Exception {
         Map<String, Object> responseMap = gson.fromJson(responseBody, Map.class);
+
+        // Check if the prompt itself was blocked before any candidate was generated
+        Map<String, Object> promptFeedback = (Map<String, Object>) responseMap.get("promptFeedback");
+        if (promptFeedback != null && promptFeedback.get("blockReason") != null) {
+            throw new ContentBlockedException("Your request couldn't be processed because it may violate content guidelines.");
+        }
+
         List<Map<String, Object>> candidates = (List<Map<String, Object>>) responseMap.get("candidates");
         if (candidates != null && !candidates.isEmpty()) {
-            Map<String, Object> content = (Map<String, Object>) candidates.get(0).get("content");
-            List<Map<String, Object>> parts = (List<Map<String, Object>>) content.get("parts");
-            if (parts != null && !parts.isEmpty()) {
-                return (String) parts.get(0).get("text");
+            Map<String, Object> candidate = candidates.get(0);
+
+            // Check if the generated response itself was blocked/cut for safety reasons
+            String finishReason = (String) candidate.get("finishReason");
+            if ("SAFETY".equals(finishReason) || "PROHIBITED_CONTENT".equals(finishReason)) {
+                throw new ContentBlockedException("The response couldn't be generated because it may violate content guidelines.");
+            }
+
+            Map<String, Object> content = (Map<String, Object>) candidate.get("content");
+            if (content != null) {
+                List<Map<String, Object>> parts = (List<Map<String, Object>>) content.get("parts");
+                if (parts != null && !parts.isEmpty()) {
+                    return (String) parts.get(0).get("text");
+                }
             }
         }
         throw new Exception("Could not find translated text in response.");
     }
 
     public void generateFromPrompt(String prompt, final TextResponseCallback callback) {
+        generateFromPromptWithRetry(prompt, callback, 0);
+    }
+
+    private void generateFromPromptWithRetry(String prompt, final TextResponseCallback callback, final int attempt) {
         List<Map<String, Object>> contents = new ArrayList<>();
         Map<String, Object> userMessage = new HashMap<>();
         userMessage.put("parts", List.of(Map.of("text", prompt)));
@@ -397,9 +424,67 @@ public class AiService {
                 if (response.isSuccessful()) {
                     try {
                         callback.onSuccess(parseSimpleTextResponse(responseBody).trim());
+                    } catch (ContentBlockedException e) {
+                        callback.onFailure(e.getMessage());
                     } catch (Exception e) {
                         callback.onFailure("Parse error: " + e.getMessage());
                     }
+                } else if (response.code() == 503 && attempt < 3) {
+                    long delayMs = (attempt + 1) * 1500L;
+                    new android.os.Handler(android.os.Looper.getMainLooper()).postDelayed(
+                            () -> generateFromPromptWithRetry(prompt, callback, attempt + 1),
+                            delayMs
+                    );
+                } else {
+                    callback.onFailure("API error: " + response.code() + " - " + responseBody);
+                }
+            }
+        });
+    }
+
+    public void generateChatResponse(List<ChatMessage> history, final TextResponseCallback callback) {
+        generateChatResponseWithRetry(history, callback, 0);
+    }
+
+    private void generateChatResponseWithRetry(List<ChatMessage> history, final TextResponseCallback callback, final int attempt) {
+        List<Map<String, Object>> contents = new ArrayList<>();
+        for (ChatMessage message : history) {
+            Map<String, Object> turn = new HashMap<>();
+            turn.put("role", message.getRole());
+            turn.put("parts", List.of(Map.of("text", message.getText())));
+            contents.add(turn);
+        }
+
+        Map<String, Object> requestBodyMap = new HashMap<>();
+        requestBodyMap.put("contents", contents);
+        String requestJson = gson.toJson(requestBodyMap);
+        RequestBody requestBody = RequestBody.create(requestJson, MediaType.parse("application/json; charset=utf-8"));
+        Request request = new Request.Builder()
+                .url(API_URL)
+                .addHeader("x-goog-api-key", API_KEY)
+                .post(requestBody)
+                .build();
+
+        client.newCall(request).enqueue(new Callback() {
+            @Override public void onFailure(Call call, IOException e) {
+                callback.onFailure("Network error: " + e.getMessage());
+            }
+            @Override public void onResponse(Call call, Response response) throws IOException {
+                String responseBody = response.body().string();
+                if (response.isSuccessful()) {
+                    try {
+                        callback.onSuccess(parseSimpleTextResponse(responseBody).trim());
+                    } catch (ContentBlockedException e) {
+                        callback.onFailure(e.getMessage());
+                    } catch (Exception e) {
+                        callback.onFailure("Parse error: " + e.getMessage());
+                    }
+                } else if (response.code() == 503 && attempt < 3) {
+                    long delayMs = (attempt + 1) * 1500L;
+                    new android.os.Handler(android.os.Looper.getMainLooper()).postDelayed(
+                            () -> generateChatResponseWithRetry(history, callback, attempt + 1),
+                            delayMs
+                    );
                 } else {
                     callback.onFailure("API error: " + response.code() + " - " + responseBody);
                 }

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/AiService.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/AiService.java
@@ -27,8 +27,7 @@ public class AiService {
 
     private static final String API_KEY = BuildConfig.GEMINI_API_KEY; // **REPLACE WITH YOUR ACTUAL API KEY!**
     //private static final String API_URL = "https://generativelanguage.googleapis.com/v1/models/gemini-2.5-flash:generateContent?key=" + API_KEY;
-    private static final String API_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemma-3-27b-it:generateContent?key="
-            + API_KEY;
+    private static final String API_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-latest:generateContent";
     //private final OkHttpClient client = new OkHttpClient();
     private final OkHttpClient client = NetworkClient.getInstance(); // use singleton client
 
@@ -372,5 +371,39 @@ public class AiService {
             }
         }
         throw new Exception("Could not find translated text in response.");
+    }
+
+    public void generateFromPrompt(String prompt, final TextResponseCallback callback) {
+        List<Map<String, Object>> contents = new ArrayList<>();
+        Map<String, Object> userMessage = new HashMap<>();
+        userMessage.put("parts", List.of(Map.of("text", prompt)));
+        contents.add(userMessage);
+        Map<String, Object> requestBodyMap = new HashMap<>();
+        requestBodyMap.put("contents", contents);
+        String requestJson = gson.toJson(requestBodyMap);
+        RequestBody requestBody = RequestBody.create(requestJson, MediaType.parse("application/json; charset=utf-8"));
+        Request request = new Request.Builder()
+                .url(API_URL)
+                .addHeader("x-goog-api-key", API_KEY)
+                .post(requestBody)
+                .build();
+
+        client.newCall(request).enqueue(new Callback() {
+            @Override public void onFailure(Call call, IOException e) {
+                callback.onFailure("Network error: " + e.getMessage());
+            }
+            @Override public void onResponse(Call call, Response response) throws IOException {
+                String responseBody = response.body().string();
+                if (response.isSuccessful()) {
+                    try {
+                        callback.onSuccess(parseSimpleTextResponse(responseBody).trim());
+                    } catch (Exception e) {
+                        callback.onFailure("Parse error: " + e.getMessage());
+                    }
+                } else {
+                    callback.onFailure("API error: " + response.code() + " - " + responseBody);
+                }
+            }
+        });
     }
 }

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/ChatAdapter.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/ChatAdapter.java
@@ -1,0 +1,56 @@
+package io.actifit.fitnesstracker.actifitfitnesstracker;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.List;
+
+public class ChatAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
+
+    private static final int TYPE_USER = 0;
+    private static final int TYPE_AI = 1;
+
+    private final List<ChatMessage> messages;
+
+    public ChatAdapter(List<ChatMessage> messages) {
+        this.messages = messages;
+    }
+
+    @Override
+    public int getItemViewType(int position) {
+        return messages.get(position).isUser() ? TYPE_USER : TYPE_AI;
+    }
+
+    @NonNull
+    @Override
+    public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        int layoutRes = (viewType == TYPE_USER) ? R.layout.item_chat_message_user : R.layout.item_chat_message_ai;
+        View view = LayoutInflater.from(parent.getContext()).inflate(layoutRes, parent, false);
+        return new MessageViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
+        ChatMessage message = messages.get(position);
+        ((MessageViewHolder) holder).bubbleText.setText(message.getText());
+    }
+
+    @Override
+    public int getItemCount() {
+        return messages.size();
+    }
+
+    static class MessageViewHolder extends RecyclerView.ViewHolder {
+        TextView bubbleText;
+
+        MessageViewHolder(View itemView) {
+            super(itemView);
+            bubbleText = itemView.findViewById(R.id.chat_bubble_text);
+        }
+    }
+}

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/ChatMessage.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/ChatMessage.java
@@ -1,0 +1,26 @@
+package io.actifit.fitnesstracker.actifitfitnesstracker;
+
+public class ChatMessage {
+    public static final String ROLE_USER = "user";
+    public static final String ROLE_AI = "model";
+
+    private final String role;
+    private final String text;
+
+    public ChatMessage(String role, String text) {
+        this.role = role;
+        this.text = text;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public boolean isUser() {
+        return ROLE_USER.equals(role);
+    }
+}

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/PostSteemitActivity.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/PostSteemitActivity.java
@@ -3,10 +3,13 @@ package io.actifit.fitnesstracker.actifitfitnesstracker;
 import static org.bitcoinj.core.TransactionBroadcast.random;
 import static java.lang.Integer.parseInt;
 
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.Instrumentation;
 import android.app.ProgressDialog;
+import java.util.List;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -103,6 +106,8 @@ import kotlin.Unit;
 import kotlinx.coroutines.BuildersKt;
 import kotlinx.coroutines.CoroutineStart;
 import kotlinx.coroutines.Dispatchers;
+import android.widget.ProgressBar;
+import android.widget.ImageButton;
 import android.widget.Spinner;
 import android.widget.ArrayAdapter;
 
@@ -2145,57 +2150,58 @@ public class PostSteemitActivity extends BaseActivity implements View.OnClickLis
         builder.setView(dialogView);
 
         EditText aiInputText = dialogView.findViewById(R.id.ai_input_text);
-        Spinner aiActionSpinner = dialogView.findViewById(R.id.ai_action_spinner);
-        Button btnQuery = dialogView.findViewById(R.id.btn_query);
-        Button btnClear = dialogView.findViewById(R.id.btn_clear);
-        TextView aiPreviewText = dialogView.findViewById(R.id.ai_preview_text);
+        ImageButton btnQuery = dialogView.findViewById(R.id.btn_query);
+        ProgressBar loadingIndicator = dialogView.findViewById(R.id.ai_loading_indicator);
+        RecyclerView chatRecyclerView = dialogView.findViewById(R.id.chat_recycler_view);
         Button btnAccept = dialogView.findViewById(R.id.btn_accept);
-        Button btnClose = dialogView.findViewById(R.id.btn_close);
-        btnAccept.setEnabled(false);
-        btnAccept.setAlpha(0.5f);
+        ImageButton btnClose = dialogView.findViewById(R.id.btn_close);
 
         EditText steemitPostContent = findViewById(R.id.steemit_post_text);
 
-        AlertDialog dialog = builder.create();
-        dialog.show();
+        List<ChatMessage> chatHistory = new ArrayList<>();
+        ChatAdapter chatAdapter = new ChatAdapter(chatHistory);
+        chatRecyclerView.setLayoutManager(new LinearLayoutManager(this));
+        chatRecyclerView.setAdapter(chatAdapter);
 
-        ArrayAdapter<String> adapter = new ArrayAdapter<>(
-                this,
-                android.R.layout.simple_spinner_item,
-                new String[]{"Query", "Summarize", "Expand"}
-        );
-        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        aiActionSpinner.setAdapter(adapter);
+        // Pre-fill the input with the existing draft, ready to send as the first message
+        //String existingDraft = steemitPostContent.getText().toString();
+        //if (!existingDraft.isEmpty()) {
+        //    aiInputText.setText(existingDraft);
+        //}
+
+        btnAccept.setEnabled(false);
+        btnAccept.setAlpha(0.5f);
+
+        AlertDialog dialog = builder.create();
+        if (dialog.getWindow() != null) {
+            dialog.getWindow().setBackgroundDrawableResource(android.R.color.transparent);
+        }
+        dialog.show();
 
         btnQuery.setOnClickListener(v -> {
             String userText = aiInputText.getText().toString().trim();
-            String action = aiActionSpinner.getSelectedItem().toString();
-
             if (userText.isEmpty()) {
-                aiPreviewText.setText(getString(R.string.ai_preview_empty_warning));
                 return;
             }
 
-            String prompt;
-            switch (action.toLowerCase()) {
-                case "summarize":
-                    prompt = "Please summarize this content:\n" + userText;
-                    break;
-                case "expand":
-                    prompt = "Please expand this content:\n" + userText;
-                    break;
-                default:
-                    prompt = userText;
-                    break;
-            }
+            chatHistory.add(new ChatMessage(ChatMessage.ROLE_USER, userText));
+            chatAdapter.notifyItemInserted(chatHistory.size() - 1);
+            chatRecyclerView.scrollToPosition(chatHistory.size() - 1);
+            aiInputText.setText("");
 
-            aiPreviewText.setText(getString(R.string.ai_is_thinking));
+            loadingIndicator.setVisibility(View.VISIBLE);
+            btnQuery.setEnabled(false);
+
             AiService aiService = new AiService();
-            aiService.generateFromPrompt(prompt, new AiService.TextResponseCallback() {
+            aiService.generateChatResponse(chatHistory, new AiService.TextResponseCallback() {
                 @Override
                 public void onSuccess(String result) {
                     runOnUiThread(() -> {
-                        aiPreviewText.setText(result);
+                        loadingIndicator.setVisibility(View.GONE);
+                        btnQuery.setEnabled(true);
+                        chatHistory.add(new ChatMessage(ChatMessage.ROLE_AI, result));
+                        chatAdapter.notifyItemInserted(chatHistory.size() - 1);
+                        chatRecyclerView.scrollToPosition(chatHistory.size() - 1);
                         if (!result.isEmpty()) {
                             btnAccept.setEnabled(true);
                             btnAccept.setAlpha(1f);
@@ -2205,19 +2211,28 @@ public class PostSteemitActivity extends BaseActivity implements View.OnClickLis
 
                 @Override
                 public void onFailure(String errorMessage) {
-                    runOnUiThread(() ->
-                            aiPreviewText.setText(getString(R.string.ai_error_prefix) + errorMessage));
+                    runOnUiThread(() -> {
+                        loadingIndicator.setVisibility(View.GONE);
+                        btnQuery.setEnabled(true);
+                        chatHistory.add(new ChatMessage(ChatMessage.ROLE_AI, errorMessage));
+                        chatAdapter.notifyItemInserted(chatHistory.size() - 1);
+                        chatRecyclerView.scrollToPosition(chatHistory.size() - 1);
+                    });
                 }
             });
         });
 
         btnAccept.setOnClickListener(v -> {
-            String acceptedText = aiPreviewText.getText().toString().trim();
-            steemitPostContent.setText(acceptedText);
+            // Apply the most recent AI reply to the post
+            for (int i = chatHistory.size() - 1; i >= 0; i--) {
+                if (!chatHistory.get(i).isUser()) {
+                    steemitPostContent.setText(chatHistory.get(i).getText());
+                    break;
+                }
+            }
             dialog.dismiss();
         });
 
-        btnClear.setOnClickListener(v -> aiInputText.setText(""));
         btnClose.setOnClickListener(v -> dialog.dismiss());
     }
 }

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/PostSteemitActivity.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/PostSteemitActivity.java
@@ -2197,6 +2197,7 @@ public class PostSteemitActivity extends BaseActivity implements View.OnClickLis
                 @Override
                 public void onSuccess(String result) {
                     runOnUiThread(() -> {
+                        if (isFinishing() || isDestroyed()) return;
                         loadingIndicator.setVisibility(View.GONE);
                         btnQuery.setEnabled(true);
                         chatHistory.add(new ChatMessage(ChatMessage.ROLE_AI, result));
@@ -2212,6 +2213,7 @@ public class PostSteemitActivity extends BaseActivity implements View.OnClickLis
                 @Override
                 public void onFailure(String errorMessage) {
                     runOnUiThread(() -> {
+                        if (isFinishing() || isDestroyed()) return;
                         loadingIndicator.setVisibility(View.GONE);
                         btnQuery.setEnabled(true);
                         chatHistory.add(new ChatMessage(ChatMessage.ROLE_AI, errorMessage));

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/PostSteemitActivity.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/PostSteemitActivity.java
@@ -103,6 +103,8 @@ import kotlin.Unit;
 import kotlinx.coroutines.BuildersKt;
 import kotlinx.coroutines.CoroutineStart;
 import kotlinx.coroutines.Dispatchers;
+import android.widget.Spinner;
+import android.widget.ArrayAdapter;
 
 public class PostSteemitActivity extends BaseActivity implements View.OnClickListener {
 
@@ -465,7 +467,8 @@ public class PostSteemitActivity extends BaseActivity implements View.OnClickLis
             isEditorExpanded = !isEditorExpanded;
             toggleEditorMode(isEditorExpanded);
         });
-
+        Button aiButton = findViewById(R.id.btn_ai_suggest);
+        aiButton.setOnClickListener(v -> showAiPopup());
         healthConnectManager = new HealthConnectManager(this);
         lifecycleCoroutineScope = LifecycleOwnerKt.getLifecycleScope(this);
 
@@ -596,12 +599,12 @@ public class PostSteemitActivity extends BaseActivity implements View.OnClickLis
 
             @Override
             public void beforeTextChanged(CharSequence s, int start,
-                    int count, int after) {
+                                          int count, int after) {
             }
 
             @Override
             public void onTextChanged(CharSequence s, int start,
-                    int before, int count) {
+                                      int before, int count) {
                 if (s.length() != 0) {
                     // mdView.setMDText(steemitPostContent.getText().toString());
                     try {
@@ -894,7 +897,9 @@ public class PostSteemitActivity extends BaseActivity implements View.OnClickLis
             // metric slider ranges
             heightSize.setValueTo(250f);
             weightSize.setValueTo(300f);
-            waistSize.setValueTo(200f); thighsSize.setValueTo(200f); chestSize.setValueTo(200f);
+            waistSize.setValueTo(200f);
+            thighsSize.setValueTo(200f);
+            chestSize.setValueTo(200f);
         } else {
             weightSizeUnit.setText(getString(R.string.lb_unit));
             heightSizeUnit.setText(getString(R.string.ft_unit));
@@ -904,7 +909,9 @@ public class PostSteemitActivity extends BaseActivity implements View.OnClickLis
             // imperial slider ranges
             heightSize.setValueTo(96f);
             weightSize.setValueTo(660f);
-            waistSize.setValueTo(79f); thighsSize.setValueTo(79f); chestSize.setValueTo(79f);
+            waistSize.setValueTo(79f);
+            thighsSize.setValueTo(79f);
+            chestSize.setValueTo(79f);
         }
         bodyFat.setValueTo(60f);
         // all sliders start at 0 (= not entered)
@@ -937,7 +944,7 @@ public class PostSteemitActivity extends BaseActivity implements View.OnClickLis
             boolean nowExpanded = measurementsContent.getVisibility() != View.VISIBLE;
             measurementsContent.setVisibility(nowExpanded ? View.VISIBLE : View.GONE);
             ObjectAnimator.ofFloat(measurementsChevron, "rotation",
-                    measurementsChevron.getRotation(), nowExpanded ? 180f : 0f)
+                            measurementsChevron.getRotation(), nowExpanded ? 180f : 0f)
                     .setDuration(200).start();
             sharedPreferences.edit().putBoolean("measurementsExpanded", nowExpanded).apply();
         });
@@ -956,9 +963,17 @@ public class PostSteemitActivity extends BaseActivity implements View.OnClickLis
         });
         steemitPostTags.addTextChangedListener(new TextWatcher() {
             private boolean processing = false;
-            @Override public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
-            @Override public void onTextChanged(CharSequence s, int start, int before, int count) {}
-            @Override public void afterTextChanged(Editable s) {
+
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
                 if (processing) return;
                 String text = s.toString();
                 if (!text.contains(",") && !text.contains(" ")) return;
@@ -966,7 +981,7 @@ public class PostSteemitActivity extends BaseActivity implements View.OnClickLis
                 String[] tokens = text.split("[,\\s]+", -1);
                 boolean endsWithDelimiter = text.length() > 0
                         && (text.charAt(text.length() - 1) == ','
-                            || Character.isWhitespace(text.charAt(text.length() - 1)));
+                        || Character.isWhitespace(text.charAt(text.length() - 1)));
                 String remaining = "";
                 for (int i = 0; i < tokens.length; i++) {
                     String token = tokens[i].trim();
@@ -1100,17 +1115,20 @@ public class PostSteemitActivity extends BaseActivity implements View.OnClickLis
                             String w = fitbit.getFieldFromProfile("weight");
                             if (!w.isEmpty())
                                 weightSize.setValue(Math.min(Float.parseFloat(w), weightSize.getValueTo()));
-                        } catch (Exception ignored) {}
+                        } catch (Exception ignored) {
+                        }
 
                         // grab and update user height
                         try {
                             String h = fitbit.getFieldFromProfile("height");
                             if (!h.isEmpty())
                                 heightSize.setValue(Math.min(Float.parseFloat(h), heightSize.getValueTo()));
-                        } catch (Exception ignored) {}
+                        } catch (Exception ignored) {
+                        }
                     }
 
-                } catch (JSONException | InterruptedException | ExecutionException | IOException e) {
+                } catch (JSONException | InterruptedException | ExecutionException |
+                         IOException e) {
                     e.printStackTrace();
                 } catch (Exception e) {
                     e.printStackTrace();
@@ -1153,7 +1171,8 @@ public class PostSteemitActivity extends BaseActivity implements View.OnClickLis
                         Log.d(MainActivity.TAG, "No auto-tracked activity found for today");
                     }
 
-                } catch (JSONException | InterruptedException | ExecutionException | IOException e) {
+                } catch (JSONException | InterruptedException | ExecutionException |
+                         IOException e) {
                     e.printStackTrace();
                 } catch (Exception e) {
                     e.printStackTrace();
@@ -1219,13 +1238,13 @@ public class PostSteemitActivity extends BaseActivity implements View.OnClickLis
 
     /**
      * function handling the display of popup notification
-     * 
+     *
      * @param notification
      * @param permLink
      */
     void displayNotification(final String notification, final ProgressDialog progress,
-            final Context context, final Activity currentActivity,
-            final String success, final String permLink) {
+                             final Context context, final Activity currentActivity,
+                             final String success, final String permLink) {
         // render result
         currentActivity.runOnUiThread(() -> {
             // hide the progressDialog
@@ -1372,8 +1391,8 @@ public class PostSteemitActivity extends BaseActivity implements View.OnClickLis
 
                 // storing account data for simple reuse. Data is not stored anywhere outside
                 // actifit App.
-                final SharedPreferences[] sharedPreferences = { getSharedPreferences("actifitSets", MODE_PRIVATE) };
-                final SharedPreferences.Editor[] editor = { sharedPreferences[0].edit() };
+                final SharedPreferences[] sharedPreferences = {getSharedPreferences("actifitSets", MODE_PRIVATE)};
+                final SharedPreferences.Editor[] editor = {sharedPreferences[0].edit()};
                 // skip on spaces, upper case, and @ symbols to properly match steem username
                 // patterns
                 editor[0].putString("actifitUser", accountUsername
@@ -1514,7 +1533,7 @@ public class PostSteemitActivity extends BaseActivity implements View.OnClickLis
                     /*
                      * Date dt = new Date();
                      * Calendar cal = Calendar.getInstance();
-                     * 
+                     *
                      * TimeZone tz = cal.getTimeZone();
                      * tz.getRawOffset();
                      */
@@ -1684,7 +1703,7 @@ public class PostSteemitActivity extends BaseActivity implements View.OnClickLis
                 }
 
                 // String inputLine;
-                final String[] result = { "" };
+                final String[] result = {""};
                 // use test url only if testing mode is on
                 String urlStr = getString(R.string.test_api_url);
                 // if (getString(R.string.test_mode).equals("off")) {
@@ -1737,14 +1756,14 @@ public class PostSteemitActivity extends BaseActivity implements View.OnClickLis
                                 e.printStackTrace();
                             }
                         }, error -> {
-                            // hide dialog
-                            // progress.hide();
-                            // actifitBalance.setText(getString(R.string.unable_fetch_afit_balance));
-                            // notification = getString(R.string.failed_post);
-                            notification = error.getMessage();
-                            displayNotification(notification, progress, context, currentActivity, "", "");
-                            error.printStackTrace();
-                        });
+                    // hide dialog
+                    // progress.hide();
+                    // actifitBalance.setText(getString(R.string.unable_fetch_afit_balance));
+                    // notification = getString(R.string.failed_post);
+                    notification = error.getMessage();
+                    displayNotification(notification, progress, context, currentActivity, "", "");
+                    error.printStackTrace();
+                });
 
                 // make sure sent only once
                 sendPostRequest.setRetryPolicy(new DefaultRetryPolicy(
@@ -1928,8 +1947,8 @@ public class PostSteemitActivity extends BaseActivity implements View.OnClickLis
 
             AlertDialog.Builder builder = new AlertDialog.Builder(steemit_post_context);
             builder.setMessage(getString(R.string.current_workout_going_charity) + " "
-                    + currentCharityDisplayName + " "
-                    + getString(R.string.current_workout_settings_based))
+                            + currentCharityDisplayName + " "
+                            + getString(R.string.current_workout_settings_based))
                     .setPositiveButton(getString(R.string.yes_button), dialogClickListener)
                     .setNegativeButton(getString(R.string.no_button), dialogClickListener).show();
         } else {
@@ -2120,4 +2139,85 @@ public class PostSteemitActivity extends BaseActivity implements View.OnClickLis
                 });
     }
 
+    private void showAiPopup() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        View dialogView = getLayoutInflater().inflate(R.layout.ai_popup, null);
+        builder.setView(dialogView);
+
+        EditText aiInputText = dialogView.findViewById(R.id.ai_input_text);
+        Spinner aiActionSpinner = dialogView.findViewById(R.id.ai_action_spinner);
+        Button btnQuery = dialogView.findViewById(R.id.btn_query);
+        Button btnClear = dialogView.findViewById(R.id.btn_clear);
+        TextView aiPreviewText = dialogView.findViewById(R.id.ai_preview_text);
+        Button btnAccept = dialogView.findViewById(R.id.btn_accept);
+        Button btnClose = dialogView.findViewById(R.id.btn_close);
+        btnAccept.setEnabled(false);
+        btnAccept.setAlpha(0.5f);
+
+        EditText steemitPostContent = findViewById(R.id.steemit_post_text);
+
+        AlertDialog dialog = builder.create();
+        dialog.show();
+
+        ArrayAdapter<String> adapter = new ArrayAdapter<>(
+                this,
+                android.R.layout.simple_spinner_item,
+                new String[]{"Query", "Summarize", "Expand"}
+        );
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        aiActionSpinner.setAdapter(adapter);
+
+        btnQuery.setOnClickListener(v -> {
+            String userText = aiInputText.getText().toString().trim();
+            String action = aiActionSpinner.getSelectedItem().toString();
+
+            if (userText.isEmpty()) {
+                aiPreviewText.setText(getString(R.string.ai_preview_empty_warning));
+                return;
+            }
+
+            String prompt;
+            switch (action.toLowerCase()) {
+                case "summarize":
+                    prompt = "Please summarize this content:\n" + userText;
+                    break;
+                case "expand":
+                    prompt = "Please expand this content:\n" + userText;
+                    break;
+                default:
+                    prompt = userText;
+                    break;
+            }
+
+            aiPreviewText.setText(getString(R.string.ai_is_thinking));
+            AiService aiService = new AiService();
+            aiService.generateFromPrompt(prompt, new AiService.TextResponseCallback() {
+                @Override
+                public void onSuccess(String result) {
+                    runOnUiThread(() -> {
+                        aiPreviewText.setText(result);
+                        if (!result.isEmpty()) {
+                            btnAccept.setEnabled(true);
+                            btnAccept.setAlpha(1f);
+                        }
+                    });
+                }
+
+                @Override
+                public void onFailure(String errorMessage) {
+                    runOnUiThread(() ->
+                            aiPreviewText.setText(getString(R.string.ai_error_prefix) + errorMessage));
+                }
+            });
+        });
+
+        btnAccept.setOnClickListener(v -> {
+            String acceptedText = aiPreviewText.getText().toString().trim();
+            steemitPostContent.setText(acceptedText);
+            dialog.dismiss();
+        });
+
+        btnClear.setOnClickListener(v -> aiInputText.setText(""));
+        btnClose.setOnClickListener(v -> dialog.dismiss());
+    }
 }

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/Utils.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/Utils.java
@@ -75,6 +75,9 @@ import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.Callback;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Arrays;
 
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
@@ -82,7 +85,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import androidx.exifinterface.media.ExifInterface;
 
-    public class Utils {
+    public class  Utils {
 
         private static final String TAG = "Utils";
 
@@ -1558,19 +1561,51 @@ import androidx.exifinterface.media.ExifInterface;
 
         return exercises;
     }
-    public static  ExerciseModel findMatchingExercise(String aiExerciseName,  Map<String, ExerciseModel> allExercisesMap) {
-        if (allExercisesMap == null || allExercisesMap.isEmpty()) {
-            return null;
-        }
-        String normalizedAIExerciseName = normalizeString(aiExerciseName);
-        for(Map.Entry<String, ExerciseModel> entry : allExercisesMap.entrySet()){
-            String databaseExerciseName = normalizeString(entry.getKey());
-            if(databaseExerciseName.contains(normalizedAIExerciseName) || normalizedAIExerciseName.contains(databaseExerciseName)){
-                return entry.getValue();
+        public static ExerciseModel findMatchingExercise(String aiExerciseName, Map<String, ExerciseModel> allExercisesMap) {
+            if (allExercisesMap == null || allExercisesMap.isEmpty() || aiExerciseName == null) {
+                return null;
             }
+
+            String normalizedAIExerciseName = normalizeString(aiExerciseName);
+
+            // 1. Try exact match first
+            for (Map.Entry<String, ExerciseModel> entry : allExercisesMap.entrySet()) {
+                if (normalizeString(entry.getKey()).equals(normalizedAIExerciseName)) {
+                    return entry.getValue();
+                }
+            }
+
+            // 2. Fall back to word-overlap scoring
+            Set<String> aiWords = new HashSet<>(Arrays.asList(normalizedAIExerciseName.split("\\s+")));
+            aiWords.removeAll(Arrays.asList("the", "a", "an", "with", "of", "and"));
+
+            ExerciseModel bestMatch = null;
+            int bestScore = 0;
+
+            for (Map.Entry<String, ExerciseModel> entry : allExercisesMap.entrySet()) {
+                String dbName = normalizeString(entry.getKey());
+                Set<String> dbWords = new HashSet<>(Arrays.asList(dbName.split("\\s+")));
+                dbWords.removeAll(Arrays.asList("the", "a", "an", "with", "of", "and"));
+
+                int score = 0;
+                for (String aiWord : aiWords) {
+                    for (String dbWord : dbWords) {
+                        if (dbWord.equals(aiWord) ||
+                                dbWord.equals(aiWord + "s") ||
+                                aiWord.equals(dbWord + "s")) {
+                            score++;
+                        }
+                    }
+                }
+
+                if (score > bestScore) {
+                    bestScore = score;
+                    bestMatch = entry.getValue();
+                }
+            }
+
+            return bestScore > 0 ? bestMatch : null;
         }
-        return null;
-    }
 
 
     public static  ExerciseModel getExerciseModel(Exercise exercise) {

--- a/app/src/main/res/drawable/ic_ai_sparkle.xml
+++ b/app/src/main/res/drawable/ic_ai_sparkle.xml
@@ -1,0 +1,6 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="@color/md_theme_primary"
+        android:pathData="M19,9l1.25,-2.75L23,5l-2.75,-1.25L19,1l-1.25,2.75L15,5l2.75,1.25L19,9zM11.5,9.5L9,4L6.5,9.5L1,12l5.5,2.5L9,20l2.5,-5.5L17,12l-5.5,-2.5zM19,15l-1.25,2.75L15,19l2.75,1.25L19,23l1.25,-2.75L23,19l-2.75,-1.25L19,15z" />
+</vector>

--- a/app/src/main/res/drawable/rounded_button_background.xml
+++ b/app/src/main/res/drawable/rounded_button_background.xml
@@ -1,0 +1,5 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="12dp" />
+    <solid android:color="@color/md_theme_inputBackground" />
+</shape>

--- a/app/src/main/res/layout/activity_post_steemit.xml
+++ b/app/src/main/res/layout/activity_post_steemit.xml
@@ -689,8 +689,14 @@
                                     style="@style/AppTheme.ToolbarIconButton"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:fontFamily="@font/font_awesome_6_solid"
-                                    android:text="  AI" />
+                                    android:contentDescription="AI Assistant"
+                                    app:icon="@drawable/ic_ai_sparkle"
+                                    app:iconTint="@color/actifitRed"
+                                    app:iconGravity="textStart"
+                                    app:iconPadding="0dp"
+                                    android:insetLeft="0dp"
+                                    android:insetRight="0dp"
+                                    android:text="" />
 
                                 <View
                                     android:layout_width="0dp"

--- a/app/src/main/res/layout/activity_post_steemit.xml
+++ b/app/src/main/res/layout/activity_post_steemit.xml
@@ -684,6 +684,13 @@
                                     android:contentDescription="Expand Editor"
                                     android:fontFamily="@font/font_awesome_6_solid"
                                     android:text="  Expand" />
+                                <com.google.android.material.button.MaterialButton
+                                    android:id="@+id/btn_ai_suggest"
+                                    style="@style/AppTheme.ToolbarIconButton"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:fontFamily="@font/font_awesome_6_solid"
+                                    android:text="  AI" />
 
                                 <View
                                     android:layout_width="0dp"

--- a/app/src/main/res/layout/ai_popup.xml
+++ b/app/src/main/res/layout/ai_popup.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="300dp"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center"
+    android:background="@android:color/white"
+    android:padding="16dp">
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/ai_popup_title"
+                android:textStyle="bold"
+                android:textSize="18sp" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_close"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="X" />
+        </LinearLayout>
+
+        <EditText
+            android:id="@+id/ai_input_text"
+            android:hint="@string/ai_hint_input"
+            android:inputType="textMultiLine"
+            android:minHeight="100dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:layout_marginBottom="12dp" />
+
+        <Spinner
+            android:id="@+id/ai_action_spinner"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:layout_marginBottom="12dp" />
+
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_query"
+                android:text="Query"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="8dp" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_clear"
+                android:text="Clear"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/ai_preview_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/ai_preview_placeholder"
+            android:textStyle="italic"
+            android:background="#EEEEEE"
+            android:padding="8dp"
+            android:minHeight="80dp"
+            android:layout_marginTop="12dp"
+            android:textIsSelectable="true" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_accept"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Accept"
+            android:layout_marginTop="16dp"
+            android:layout_gravity="center_horizontal" />
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/ai_popup.xml
+++ b/app/src/main/res/layout/ai_popup.xml
@@ -1,21 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="300dp"
-    android:layout_height="wrap_content"
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="340dp"
+    android:layout_height="480dp"
     android:layout_gravity="center"
-    android:background="@android:color/white"
-    android:padding="16dp">
+    app:cardBackgroundColor="?attr/colorSurface"
+    app:cardCornerRadius="16dp"
+    app:cardElevation="8dp">
 
     <LinearLayout
         android:orientation="vertical"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="match_parent">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            android:gravity="center_vertical">
+            android:gravity="center_vertical"
+            android:padding="@dimen/spacing_md">
+
+            <ImageView
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:src="@drawable/ic_ai_sparkle"
+                android:layout_marginEnd="@dimen/spacing_sm" />
 
             <TextView
                 android:layout_width="0dp"
@@ -23,70 +32,76 @@
                 android:layout_weight="1"
                 android:text="@string/ai_popup_title"
                 android:textStyle="bold"
-                android:textSize="18sp" />
+                android:textColor="@color/md_theme_onSurface"
+                android:textSize="16sp" />
 
-            <com.google.android.material.button.MaterialButton
+            <ImageButton
                 android:id="@+id/btn_close"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="X" />
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:src="@android:drawable/ic_menu_close_clear_cancel"
+                app:tint="@color/md_theme_onSurface"
+                android:contentDescription="Close" />
         </LinearLayout>
 
-        <EditText
-            android:id="@+id/ai_input_text"
-            android:hint="@string/ai_hint_input"
-            android:inputType="textMultiLine"
-            android:minHeight="100dp"
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/chat_recycler_view"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
-            android:layout_marginBottom="12dp" />
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:paddingStart="@dimen/spacing_md"
+            android:paddingEnd="@dimen/spacing_md"
+            android:clipToPadding="false" />
 
-        <Spinner
-            android:id="@+id/ai_action_spinner"
-            android:layout_width="match_parent"
-            android:layout_height="48dp"
-            android:layout_marginBottom="12dp" />
+        <ProgressBar
+            android:id="@+id/ai_loading_indicator"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_gravity="center"
+            android:layout_marginBottom="@dimen/spacing_sm"
+            android:visibility="gone" />
 
         <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:orientation="horizontal"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center">
+            android:gravity="center_vertical"
+            android:padding="@dimen/spacing_sm">
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/btn_query"
-                android:text="Query"
-                android:layout_width="wrap_content"
+            <EditText
+                android:id="@+id/ai_input_text"
+                android:hint="@string/ai_hint_input"
+                android:inputType="textMultiLine"
+                android:maxLines="3"
+                android:background="@drawable/rounded_button_background"
+                android:backgroundTint="@color/md_theme_inputBackground"
+                android:textColor="@color/md_theme_onSurface"
+                android:padding="@dimen/spacing_sm"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginEnd="8dp" />
+                android:layout_weight="1"
+                android:layout_marginEnd="@dimen/spacing_sm" />
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/btn_clear"
-                android:text="Clear"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content" />
+            <ImageButton
+                android:id="@+id/btn_query"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:background="@drawable/rounded_button_background"
+                android:backgroundTint="@color/md_theme_primary"
+                android:src="@android:drawable/ic_menu_send"
+                app:tint="@color/md_theme_onPrimary"
+                android:contentDescription="Send" />
         </LinearLayout>
-
-        <TextView
-            android:id="@+id/ai_preview_text"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/ai_preview_placeholder"
-            android:textStyle="italic"
-            android:background="#EEEEEE"
-            android:padding="8dp"
-            android:minHeight="80dp"
-            android:layout_marginTop="12dp"
-            android:textIsSelectable="true" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_accept"
-            android:layout_width="wrap_content"
+            android:text="@string/ai_accept_button"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Accept"
-            android:layout_marginTop="16dp"
-            android:layout_gravity="center_horizontal" />
+            android:layout_margin="@dimen/spacing_sm"
+            app:backgroundTint="@color/md_theme_primary"
+            android:textColor="@color/md_theme_onPrimary" />
 
     </LinearLayout>
-</ScrollView>
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/item_chat_message_ai.xml
+++ b/app/src/main/res/layout/item_chat_message_ai.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:gravity="start"
+    android:paddingTop="@dimen/spacing_xs"
+    android:paddingBottom="@dimen/spacing_xs">
+
+    <TextView
+        android:id="@+id/chat_bubble_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="60dp"
+        android:background="@drawable/rounded_button_background"
+        android:backgroundTint="@color/md_theme_cardBackground"
+        android:textColor="@color/md_theme_onSurface"
+        android:padding="@dimen/spacing_sm"
+        android:textIsSelectable="true" />
+</LinearLayout>

--- a/app/src/main/res/layout/item_chat_message_user.xml
+++ b/app/src/main/res/layout/item_chat_message_user.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:gravity="end"
+    android:paddingTop="@dimen/spacing_xs"
+    android:paddingBottom="@dimen/spacing_xs">
+
+    <TextView
+        android:id="@+id/chat_bubble_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="60dp"
+        android:background="@drawable/rounded_button_background"
+        android:backgroundTint="@color/md_theme_primary"
+        android:textColor="@color/md_theme_onPrimary"
+        android:padding="@dimen/spacing_sm"
+        android:textIsSelectable="true" />
+</LinearLayout>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -750,5 +750,16 @@
     <string name="ai_popup_title">مساعد الذكاء الاصطناعي</string>
     <string name="ai_hint_input">بماذا تريد المساعدة؟</string>
     <string name="ai_accept_button">قبول</string>
+    <string name="dhf_vote_title">ادعم عملنا 💪</string>
+    <string name="dhf_vote_message">تصويت واحد بضغطة واحدة على اقتراحنا يساعد في دعم عملنا المستمر على هايف — ولا يكلفك شيئًا.</string>
+    <string name="dhf_vote_btn_hivesigner">صوّت بضغطة واحدة (Hivesigner)</string>
+    <string name="dhf_vote_btn_peakd">اقرأ وصوّت (PeakD)</string>
+    <string name="dhf_vote_btn_later">ربما لاحقًا</string>
+    <string name="dhf_vote_btn_vote_now">صوّت الآن</string>
+    <string name="dhf_vote_thanks">شكرًا لدعمك أكتيفت! 🙏</string>
+    <string name="hive_transactions_lbl">معاملات هايف</string>
+    <string name="hive_transactions_error">تعذر تحميل معاملات هايف</string>
+    <string name="hive_transactions_empty">لم يتم العثور على معاملات مالية</string>
+    <string name="load_more_lbl">تحميل المزيد</string>
 </resources>
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -747,5 +747,8 @@
     <string name="profile_companion_picker_title">اختر حيوانك الروحي</string>
     <string name="profile_streak_at_risk">⚠️ بقيت %1$s خطوة اليوم للحفاظ على سلسلتك المكوّنة من %2$d يوم</string>
     <string name="profile_metrics_legend">🚶 %1$s خطوة · 📏 %2$s كم · 🔥 %3$s سعرة</string>
+    <string name="ai_popup_title">مساعد الذكاء الاصطناعي</string>
+    <string name="ai_hint_input">بماذا تريد المساعدة؟</string>
+    <string name="ai_accept_button">قبول</string>
 </resources>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -740,5 +740,9 @@
     <string name="profile_companion_picker_title">Wähle dein Krafttier</string>
     <string name="profile_streak_at_risk">⚠️ Noch %1$s Schritte heute, um deine %2$d-Tage-Serie zu erhalten</string>
     <string name="profile_metrics_legend">🚶 %1$s Schritte · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="ai_popup_title">KI-Assistent</string>
+    <string name="ai_hint_input">Wobei möchtest du Hilfe?</string>
+    <string name="ai_accept_button">Übernehmen</string>
 </resources>
+
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -743,6 +743,17 @@
     <string name="ai_popup_title">KI-Assistent</string>
     <string name="ai_hint_input">Wobei möchtest du Hilfe?</string>
     <string name="ai_accept_button">Übernehmen</string>
+    <string name="dhf_vote_title">Unterstütze unsere Arbeit 💪</string>
+    <string name="dhf_vote_message">Eine 1-Tap-Abstimmung für unseren Vorschlag hilft, unsere laufende Arbeit auf Hive zu unterstützen — und kostet dich nichts.</string>
+    <string name="dhf_vote_btn_hivesigner">In 1 Tap abstimmen (Hivesigner)</string>
+    <string name="dhf_vote_btn_peakd">Lesen &amp; abstimmen (PeakD)</string>
+    <string name="dhf_vote_btn_later">Vielleicht später</string>
+    <string name="dhf_vote_btn_vote_now">Jetzt abstimmen</string>
+    <string name="dhf_vote_thanks">Danke, dass du Actifit unterstützt! 🙏</string>
+    <string name="hive_transactions_lbl">Hive-Transaktionen</string>
+    <string name="hive_transactions_error">Hive-Transaktionen konnten nicht geladen werden</string>
+    <string name="hive_transactions_empty">Keine finanziellen Transaktionen gefunden</string>
+    <string name="load_more_lbl">Mehr laden</string>
 </resources>
 
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -742,5 +742,16 @@
     <string name="ai_popup_title">Asistente de IA</string>
     <string name="ai_hint_input">¿En qué te gustaría que te ayudara?</string>
     <string name="ai_accept_button">Aceptar</string>
+    <string name="dhf_vote_title">Apoya nuestro trabajo 💪</string>
+    <string name="dhf_vote_message">Un voto con un solo toque en nuestra propuesta ayuda a apoyar nuestro trabajo continuo en Hive — y no te cuesta nada.</string>
+    <string name="dhf_vote_btn_hivesigner">Vota en 1 toque (Hivesigner)</string>
+    <string name="dhf_vote_btn_peakd">Lee y vota (PeakD)</string>
+    <string name="dhf_vote_btn_later">Quizás más tarde</string>
+    <string name="dhf_vote_btn_vote_now">Votar ahora</string>
+    <string name="dhf_vote_thanks">¡Gracias por apoyar a Actifit! 🙏</string>
+    <string name="hive_transactions_lbl">Transacciones de Hive</string>
+    <string name="hive_transactions_error">No se pudieron cargar las transacciones de Hive</string>
+    <string name="hive_transactions_empty">No se encontraron transacciones financieras</string>
+    <string name="load_more_lbl">Cargar más</string>
 </resources>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -739,5 +739,8 @@
     <string name="profile_companion_picker_title">Elige tu animal espiritual</string>
     <string name="profile_streak_at_risk">⚠️ Te faltan %1$s pasos hoy para mantener tu racha de %2$d días</string>
     <string name="profile_metrics_legend">🚶 %1$s pasos · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="ai_popup_title">Asistente de IA</string>
+    <string name="ai_hint_input">¿En qué te gustaría que te ayudara?</string>
+    <string name="ai_accept_button">Aceptar</string>
 </resources>
 

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -739,5 +739,16 @@
     <string name="ai_popup_title">एआई सहायक</string>
     <string name="ai_hint_input">आपको किस चीज़ में मदद चाहिए?</string>
     <string name="ai_accept_button">स्वीकार करें</string>
+    <string name="dhf_vote_title">हमारे काम का समर्थन करें 💪</string>
+    <string name="dhf_vote_message">हमारे प्रस्ताव पर एक टैप में वोट देने से Hive पर हमारे चल रहे काम को समर्थन मिलता है — और इसका आपको कोई खर्च नहीं आता।</string>
+    <string name="dhf_vote_btn_hivesigner">1 टैप में वोट करें (Hivesigner)</string>
+    <string name="dhf_vote_btn_peakd">पढ़ें और वोट करें (PeakD)</string>
+    <string name="dhf_vote_btn_later">शायद बाद में</string>
+    <string name="dhf_vote_btn_vote_now">अभी वोट करें</string>
+    <string name="dhf_vote_thanks">Actifit का समर्थन करने के लिए धन्यवाद! 🙏</string>
+    <string name="hive_transactions_lbl">Hive लेनदेन</string>
+    <string name="hive_transactions_error">Hive लेनदेन लोड नहीं हो सके</string>
+    <string name="hive_transactions_empty">कोई वित्तीय लेनदेन नहीं मिला</string>
+    <string name="load_more_lbl">और लोड करें</string>
 </resources>
 

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -736,5 +736,8 @@
     <string name="profile_companion_picker_title">अपना आत्मिक पशु चुनें</string>
     <string name="profile_streak_at_risk">⚠️ अपनी %2$d-दिन की श्रृंखला बनाए रखने के लिए आज %1$s कदम बाकी हैं</string>
     <string name="profile_metrics_legend">🚶 %1$s कदम · 📏 %2$s किमी · 🔥 %3$s कैलोरी</string>
+    <string name="ai_popup_title">एआई सहायक</string>
+    <string name="ai_hint_input">आपको किस चीज़ में मदद चाहिए?</string>
+    <string name="ai_accept_button">स्वीकार करें</string>
 </resources>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -739,5 +739,16 @@
     <string name="ai_popup_title">Assistente IA</string>
     <string name="ai_hint_input">Con cosa vorresti essere aiutato?</string>
     <string name="ai_accept_button">Accetta</string>
+    <string name="dhf_vote_title">Sostieni il nostro lavoro 💪</string>
+    <string name="dhf_vote_message">Un voto con un tocco sulla nostra proposta aiuta a sostenere il nostro lavoro continuo su Hive — e non ti costa nulla.</string>
+    <string name="dhf_vote_btn_hivesigner">Vota in 1 tocco (Hivesigner)</string>
+    <string name="dhf_vote_btn_peakd">Leggi e vota (PeakD)</string>
+    <string name="dhf_vote_btn_later">Forse più tardi</string>
+    <string name="dhf_vote_btn_vote_now">Vota ora</string>
+    <string name="dhf_vote_thanks">Grazie per aver sostenuto Actifit! 🙏</string>
+    <string name="hive_transactions_lbl">Transazioni Hive</string>
+    <string name="hive_transactions_error">Impossibile caricare le transazioni Hive</string>
+    <string name="hive_transactions_empty">Nessuna transazione finanziaria trovata</string>
+    <string name="load_more_lbl">Carica altro</string>
 </resources>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -736,5 +736,8 @@
     <string name="profile_companion_picker_title">Scegli il tuo animale guida</string>
     <string name="profile_streak_at_risk">⚠️ Ti mancano %1$s passi oggi per mantenere la tua serie di %2$d giorni</string>
     <string name="profile_metrics_legend">🚶 %1$s passi · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="ai_popup_title">Assistente IA</string>
+    <string name="ai_hint_input">Con cosa vorresti essere aiutato?</string>
+    <string name="ai_accept_button">Accetta</string>
 </resources>
 

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -736,5 +736,8 @@
     <string name="profile_companion_picker_title">수호 동물 선택</string>
     <string name="profile_streak_at_risk">⚠️ %2$d일 연속 기록을 유지하려면 오늘 %1$s걸음 남았습니다</string>
     <string name="profile_metrics_legend">🚶 %1$s걸음 · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="ai_popup_title">AI 어시스턴트</string>
+    <string name="ai_hint_input">무엇을 도와드릴까요?</string>
+    <string name="ai_accept_button">수락</string>
 </resources>
 

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -739,5 +739,16 @@
     <string name="ai_popup_title">AI 어시스턴트</string>
     <string name="ai_hint_input">무엇을 도와드릴까요?</string>
     <string name="ai_accept_button">수락</string>
+    <string name="dhf_vote_title">저희 활동을 응원해 주세요 💪</string>
+    <string name="dhf_vote_message">저희 제안에 한 번의 탭으로 투표하시면 Hive에서 계속되는 저희 활동을 지원하는 데 도움이 됩니다 — 비용은 전혀 들지 않습니다.</string>
+    <string name="dhf_vote_btn_hivesigner">한 번의 탭으로 투표 (Hivesigner)</string>
+    <string name="dhf_vote_btn_peakd">읽고 투표하기 (PeakD)</string>
+    <string name="dhf_vote_btn_later">나중에</string>
+    <string name="dhf_vote_btn_vote_now">지금 투표하기</string>
+    <string name="dhf_vote_thanks">Actifit를 응원해 주셔서 감사합니다! 🙏</string>
+    <string name="hive_transactions_lbl">Hive 거래 내역</string>
+    <string name="hive_transactions_error">Hive 거래 내역을 불러올 수 없습니다</string>
+    <string name="hive_transactions_empty">금융 거래 내역이 없습니다</string>
+    <string name="load_more_lbl">더 보기</string>
 </resources>
 

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -736,5 +736,8 @@
     <string name="profile_companion_picker_title">Kies je totemdier</string>
     <string name="profile_streak_at_risk">⚠️ Nog %1$s stappen vandaag om je reeks van %2$d dagen te behouden</string>
     <string name="profile_metrics_legend">🚶 %1$s stappen · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="ai_popup_title">AI-assistent</string>
+    <string name="ai_hint_input">Waarmee wil je hulp?</string>
+    <string name="ai_accept_button">Accepteren</string>
 </resources>
 

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -739,5 +739,16 @@
     <string name="ai_popup_title">AI-assistent</string>
     <string name="ai_hint_input">Waarmee wil je hulp?</string>
     <string name="ai_accept_button">Accepteren</string>
+    <string name="dhf_vote_title">Steun ons werk 💪</string>
+    <string name="dhf_vote_message">Een stem met één tik op ons voorstel helpt ons voortdurende werk op Hive te ondersteunen — en het kost je niets.</string>
+    <string name="dhf_vote_btn_hivesigner">Stem in 1 tik (Hivesigner)</string>
+    <string name="dhf_vote_btn_peakd">Lees &amp; stem (PeakD)</string>
+    <string name="dhf_vote_btn_later">Misschien later</string>
+    <string name="dhf_vote_btn_vote_now">Nu stemmen</string>
+    <string name="dhf_vote_thanks">Bedankt voor je steun aan Actifit! 🙏</string>
+    <string name="hive_transactions_lbl">Hive-transacties</string>
+    <string name="hive_transactions_error">Hive-transacties konden niet worden geladen</string>
+    <string name="hive_transactions_empty">Geen financiële transacties gevonden</string>
+    <string name="load_more_lbl">Meer laden</string>
 </resources>
 

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -739,6 +739,17 @@
     <string name="ai_popup_title">Assistente de IA</string>
     <string name="ai_hint_input">Com o que você gostaria de ajuda?</string>
     <string name="ai_accept_button">Aceitar</string>
+    <string name="dhf_vote_title">Apoie nosso trabalho 💪</string>
+    <string name="dhf_vote_message">Um voto com um toque na nossa proposta ajuda a apoiar nosso trabalho contínuo na Hive — e não custa nada para você.</string>
+    <string name="dhf_vote_btn_hivesigner">Vote em 1 toque (Hivesigner)</string>
+    <string name="dhf_vote_btn_peakd">Leia e vote (PeakD)</string>
+    <string name="dhf_vote_btn_later">Talvez mais tarde</string>
+    <string name="dhf_vote_btn_vote_now">Votar agora</string>
+    <string name="dhf_vote_thanks">Obrigado por apoiar o Actifit! 🙏</string>
+    <string name="hive_transactions_lbl">Transações Hive</string>
+    <string name="hive_transactions_error">Não foi possível carregar as transações Hive</string>
+    <string name="hive_transactions_empty">Nenhuma transação financeira encontrada</string>
+    <string name="load_more_lbl">Carregar mais</string>
 </resources>
 
 

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -736,6 +736,9 @@
     <string name="profile_companion_picker_title">Escolha seu animal espiritual</string>
     <string name="profile_streak_at_risk">⚠️ Faltam %1$s passos hoje para manter sua sequência de %2$d dias</string>
     <string name="profile_metrics_legend">🚶 %1$s passos · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="ai_popup_title">Assistente de IA</string>
+    <string name="ai_hint_input">Com o que você gostaria de ajuda?</string>
+    <string name="ai_accept_button">Aceitar</string>
 </resources>
 
 

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -736,5 +736,8 @@
     <string name="profile_companion_picker_title">Escolhe o teu animal espiritual</string>
     <string name="profile_streak_at_risk">⚠️ Faltam %1$s passos hoje para manteres a tua sequência de %2$d dias</string>
     <string name="profile_metrics_legend">🚶 %1$s passos · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="ai_popup_title">Assistente de IA</string>
+    <string name="ai_hint_input">Com o que você gostaria de ajuda?</string>
+    <string name="ai_accept_button">Aceitar</string>
 </resources>
 

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -739,5 +739,16 @@
     <string name="ai_popup_title">Assistente de IA</string>
     <string name="ai_hint_input">Com o que você gostaria de ajuda?</string>
     <string name="ai_accept_button">Aceitar</string>
+    <string name="dhf_vote_title">Apoie o nosso trabalho 💪</string>
+    <string name="dhf_vote_message">Um voto com um toque na nossa proposta ajuda a apoiar o nosso trabalho contínuo na Hive — e não lhe custa nada.</string>
+    <string name="dhf_vote_btn_hivesigner">Vote em 1 toque (Hivesigner)</string>
+    <string name="dhf_vote_btn_peakd">Leia e vote (PeakD)</string>
+    <string name="dhf_vote_btn_later">Talvez mais tarde</string>
+    <string name="dhf_vote_btn_vote_now">Votar agora</string>
+    <string name="dhf_vote_thanks">Obrigado por apoiar a Actifit! 🙏</string>
+    <string name="hive_transactions_lbl">Transações Hive</string>
+    <string name="hive_transactions_error">Não foi possível carregar as transações Hive</string>
+    <string name="hive_transactions_empty">Nenhuma transação financeira encontrada</string>
+    <string name="load_more_lbl">Carregar mais</string>
 </resources>
 

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -735,4 +735,7 @@
     <string name="profile_companion_picker_title">Ruh hayvanını seç</string>
     <string name="profile_streak_at_risk">⚠️ %2$d günlük serini korumak için bugün %1$s adım kaldı</string>
     <string name="profile_metrics_legend">🚶 %1$s adım · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="ai_popup_title">Yapay Zeka Asistanı</string>
+    <string name="ai_hint_input">Ne konuda yardım istersiniz?</string>
+    <string name="ai_accept_button">Kabul Et</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -738,4 +738,15 @@
     <string name="ai_popup_title">Yapay Zeka Asistanı</string>
     <string name="ai_hint_input">Ne konuda yardım istersiniz?</string>
     <string name="ai_accept_button">Kabul Et</string>
+    <string name="dhf_vote_title">Çalışmamızı destekleyin 💪</string>
+    <string name="dhf_vote_message">Teklifimize tek dokunuşla oy vermek, Hive üzerindeki sürekli çalışmamızı desteklemenize yardımcı olur — ve size hiçbir maliyeti yoktur.</string>
+    <string name="dhf_vote_btn_hivesigner">1 dokunuşla oy verin (Hivesigner)</string>
+    <string name="dhf_vote_btn_peakd">Okuyun ve oy verin (PeakD)</string>
+    <string name="dhf_vote_btn_later">Belki sonra</string>
+    <string name="dhf_vote_btn_vote_now">Şimdi oy ver</string>
+    <string name="dhf_vote_thanks">Actifit\'i desteklediğiniz için teşekkürler! 🙏</string>
+    <string name="hive_transactions_lbl">Hive İşlemleri</string>
+    <string name="hive_transactions_error">Hive işlemleri yüklenemedi</string>
+    <string name="hive_transactions_empty">Hiçbir finansal işlem bulunamadı</string>
+    <string name="load_more_lbl">Daha Fazla Yükle</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -735,5 +735,8 @@
     <string name="profile_companion_picker_title">Обери свою тварину-духа</string>
     <string name="profile_streak_at_risk">⚠️ Ще %1$s кроків сьогодні, щоб зберегти серію з %2$d днів</string>
     <string name="profile_metrics_legend">🚶 %1$s кроків · 📏 %2$s км · 🔥 %3$s ккал</string>
+    <string name="ai_popup_title">ШІ-асистент</string>
+    <string name="ai_hint_input">З чим би ви хотіли допомогти?</string>
+    <string name="ai_accept_button">Прийняти</string>
 </resources>
 

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -738,5 +738,16 @@
     <string name="ai_popup_title">ШІ-асистент</string>
     <string name="ai_hint_input">З чим би ви хотіли допомогти?</string>
     <string name="ai_accept_button">Прийняти</string>
+    <string name="dhf_vote_title">Підтримайте нашу роботу 💪</string>
+    <string name="dhf_vote_message">Голосування в один дотик за нашу пропозицію допомагає підтримувати нашу постійну роботу на Hive — і це не коштує вам нічого.</string>
+    <string name="dhf_vote_btn_hivesigner">Проголосувати в 1 дотик (Hivesigner)</string>
+    <string name="dhf_vote_btn_peakd">Прочитати та проголосувати (PeakD)</string>
+    <string name="dhf_vote_btn_later">Можливо пізніше</string>
+    <string name="dhf_vote_btn_vote_now">Голосувати зараз</string>
+    <string name="dhf_vote_thanks">Дякуємо за підтримку Actifit! 🙏</string>
+    <string name="hive_transactions_lbl">Транзакції Hive</string>
+    <string name="hive_transactions_error">Не вдалося завантажити транзакції Hive</string>
+    <string name="hive_transactions_empty">Фінансових транзакцій не знайдено</string>
+    <string name="load_more_lbl">Завантажити більше</string>
 </resources>
 

--- a/app/src/main/res/values-yo/strings.xml
+++ b/app/src/main/res/values-yo/strings.xml
@@ -736,5 +736,8 @@
     <string name="profile_companion_picker_title">Yan ẹranko ẹ̀mí rẹ</string>
     <string name="profile_streak_at_risk">⚠️ %1$s ìṣísẹ̀ ló kù lónìí láti pa ọ̀wọ́ ọjọ́ %2$d rẹ mọ́</string>
     <string name="profile_metrics_legend">🚶 %1$s ìṣísẹ̀ · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="ai_popup_title">Olùrànlọ́wọ́ AI</string>
+    <string name="ai_hint_input">Kí ni o fẹ́ ìrànlọ́wọ́ pẹ̀lú?</string>
+    <string name="ai_accept_button">Gbà</string>
 </resources>
 

--- a/app/src/main/res/values-yo/strings.xml
+++ b/app/src/main/res/values-yo/strings.xml
@@ -739,5 +739,16 @@
     <string name="ai_popup_title">Olùrànlọ́wọ́ AI</string>
     <string name="ai_hint_input">Kí ni o fẹ́ ìrànlọ́wọ́ pẹ̀lú?</string>
     <string name="ai_accept_button">Gbà</string>
+    <string name="dhf_vote_title">Ṣe àtìlẹyìn iṣẹ́ wa 💪</string>
+    <string name="dhf_vote_message">Ìdìbò kan pẹ̀lú ìfọwọ́kàn kan lórí ìdábàá wa ń ràn wá lọ́wọ́ láti ṣe àtìlẹyìn iṣẹ́ wa tí ń lọ lórí Hive — kò sì ná ọ ohunkóhun.</string>
+    <string name="dhf_vote_btn_hivesigner">Dìbò ní ìfọwọ́kàn 1 (Hivesigner)</string>
+    <string name="dhf_vote_btn_peakd">Ka àti dìbò (PeakD)</string>
+    <string name="dhf_vote_btn_later">Bóyá nígbà mìíràn</string>
+    <string name="dhf_vote_btn_vote_now">Dìbò nísinsìnyí</string>
+    <string name="dhf_vote_thanks">A dúpẹ́ fún àtìlẹyìn Actifit! 🙏</string>
+    <string name="hive_transactions_lbl">Ìṣòwò Hive</string>
+    <string name="hive_transactions_error">A kò lè gbé ìṣòwò Hive wọlé</string>
+    <string name="hive_transactions_empty">A kò rí ìṣòwò owó kankan</string>
+    <string name="load_more_lbl">Gbé sí i wọlé</string>
 </resources>
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -735,4 +735,7 @@
     <string name="profile_companion_picker_title">选择你的灵兽</string>
     <string name="profile_streak_at_risk">⚠️ 今天还差 %1$s 步即可保持你的 %2$d 天连续记录</string>
     <string name="profile_metrics_legend">🚶 %1$s 步 · 📏 %2$s 公里 · 🔥 %3$s 千卡</string>
+    <string name="ai_popup_title">AI 助手</string>
+    <string name="ai_hint_input">您需要什么帮助？</string>
+    <string name="ai_accept_button">接受</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -738,4 +738,15 @@
     <string name="ai_popup_title">AI 助手</string>
     <string name="ai_hint_input">您需要什么帮助？</string>
     <string name="ai_accept_button">接受</string>
+    <string name="dhf_vote_title">支持我们的工作 💪</string>
+    <string name="dhf_vote_message">为我们的提案投上一票，只需轻轻一点，就能支持我们在 Hive 上持续开展的工作——而且完全免费。</string>
+    <string name="dhf_vote_btn_hivesigner">一键投票 (Hivesigner)</string>
+    <string name="dhf_vote_btn_peakd">阅读并投票 (PeakD)</string>
+    <string name="dhf_vote_btn_later">以后再说</string>
+    <string name="dhf_vote_btn_vote_now">立即投票</string>
+    <string name="dhf_vote_thanks">感谢您支持 Actifit！🙏</string>
+    <string name="hive_transactions_lbl">Hive 交易记录</string>
+    <string name="hive_transactions_error">无法加载 Hive 交易记录</string>
+    <string name="hive_transactions_empty">未找到任何财务交易记录</string>
+    <string name="load_more_lbl">加载更多</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -731,4 +731,11 @@
     <string name="dhf_vote_btn_later">Maybe later</string>
     <string name="dhf_vote_btn_vote_now">Vote now</string>
     <string name="dhf_vote_thanks">Thanks for supporting Actifit! 🙏</string>
+    <string name="ai_popup_title">AI Assistant</string>
+    <string name="ai_hint_input">Enter your content here.</string>
+    <string name="ai_preview_placeholder">AI response will appear here.</string>
+    <string name="ai_preview_empty_warning">Please enter some text first.</string>
+    <string name="ai_is_thinking">[AI is thinking…]</string>
+    <string name="ai_error_prefix">[AI error] </string>
+    <string name="ai_no_valid_response">No valid AI response to accept.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -732,10 +732,13 @@
     <string name="dhf_vote_btn_vote_now">Vote now</string>
     <string name="dhf_vote_thanks">Thanks for supporting Actifit! 🙏</string>
     <string name="ai_popup_title">AI Assistant</string>
-    <string name="ai_hint_input">Enter your content here.</string>
+    <string name="ai_hint_input">What would you like help with?</string>
     <string name="ai_preview_placeholder">AI response will appear here.</string>
     <string name="ai_preview_empty_warning">Please enter some text first.</string>
     <string name="ai_is_thinking">[AI is thinking…]</string>
     <string name="ai_error_prefix">[AI error] </string>
     <string name="ai_no_valid_response">No valid AI response to accept.</string>
+    <string name="ai_generate_button">Generate</string>
+    <string name="ai_regenerate_button">Regenerate</string>
+    <string name="ai_accept_button">Accept</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -733,12 +733,5 @@
     <string name="dhf_vote_thanks">Thanks for supporting Actifit! 🙏</string>
     <string name="ai_popup_title">AI Assistant</string>
     <string name="ai_hint_input">What would you like help with?</string>
-    <string name="ai_preview_placeholder">AI response will appear here.</string>
-    <string name="ai_preview_empty_warning">Please enter some text first.</string>
-    <string name="ai_is_thinking">[AI is thinking…]</string>
-    <string name="ai_error_prefix">[AI error] </string>
-    <string name="ai_no_valid_response">No valid AI response to accept.</string>
-    <string name="ai_generate_button">Generate</string>
-    <string name="ai_regenerate_button">Regenerate</string>
     <string name="ai_accept_button">Accept</string>
 </resources>


### PR DESCRIPTION
## What this does
Adds translations for 11 strings that were present in English (`values/strings.xml`) but missing across all 13 locale files: the DHF proposal vote prompt (`dhf_vote_title`, `dhf_vote_message`, `dhf_vote_thanks`, and 4 button labels) and Hive transactions strings (`hive_transactions_lbl`, `hive_transactions_error`, `hive_transactions_empty`, `load_more_lbl`).

## How the gap was found
Compared string names in `values/strings.xml` against each locale file to find real gaps (excluding non-translatable format strings, URLs, and brand/icon references already correctly marked `translatable="false"`).

## Notes
- Fixed an unescaped apostrophe in the Turkish translation that broke the build (`Actifit'i` → `Actifit\'i`)
- Flagging `yo` (Yoruba) again as not native-speaker verified, same as the previous PR
- Confirmed via `.\gradlew.bat assembleDebug` — build succeeds