### PR TITLE
Translate DHF vote prompt and Hive transactions strings

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -747,5 +747,17 @@
     <string name="profile_companion_picker_title">اختر حيوانك الروحي</string>
     <string name="profile_streak_at_risk">⚠️ بقيت %1$s خطوة اليوم للحفاظ على سلسلتك المكوّنة من %2$d يوم</string>
     <string name="profile_metrics_legend">🚶 %1$s خطوة · 📏 %2$s كم · 🔥 %3$s سعرة</string>
+    <string name="dhf_vote_title">ادعم عملنا 💪</string>
+    <string name="dhf_vote_message">تصويت واحد بضغطة واحدة على اقتراحنا يساعد في دعم عملنا المستمر على هايف — ولا يكلفك شيئًا.</string>
+    <string name="dhf_vote_btn_hivesigner">صوّت بضغطة واحدة (Hivesigner)</string>
+    <string name="dhf_vote_btn_peakd">اقرأ وصوّت (PeakD)</string>
+    <string name="dhf_vote_btn_later">ربما لاحقًا</string>
+    <string name="dhf_vote_btn_vote_now">صوّت الآن</string>
+    <string name="dhf_vote_thanks">شكرًا لدعمك أكتيفت! 🙏</string>
+    <string name="hive_transactions_lbl">معاملات هايف</string>
+    <string name="hive_transactions_error">تعذر تحميل معاملات هايف</string>
+    <string name="hive_transactions_empty">لم يتم العثور على معاملات مالية</string>
+    <string name="load_more_lbl">تحميل المزيد</string>
 </resources>
+
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -740,5 +740,17 @@
     <string name="profile_companion_picker_title">Wähle dein Krafttier</string>
     <string name="profile_streak_at_risk">⚠️ Noch %1$s Schritte heute, um deine %2$d-Tage-Serie zu erhalten</string>
     <string name="profile_metrics_legend">🚶 %1$s Schritte · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="dhf_vote_title">Unterstütze unsere Arbeit 💪</string>
+    <string name="dhf_vote_message">Eine 1-Tap-Abstimmung für unseren Vorschlag hilft, unsere laufende Arbeit auf Hive zu unterstützen — und kostet dich nichts.</string>
+    <string name="dhf_vote_btn_hivesigner">In 1 Tap abstimmen (Hivesigner)</string>
+    <string name="dhf_vote_btn_peakd">Lesen &amp; abstimmen (PeakD)</string>
+    <string name="dhf_vote_btn_later">Vielleicht später</string>
+    <string name="dhf_vote_btn_vote_now">Jetzt abstimmen</string>
+    <string name="dhf_vote_thanks">Danke, dass du Actifit unterstützt! 🙏</string>
+    <string name="hive_transactions_lbl">Hive-Transaktionen</string>
+    <string name="hive_transactions_error">Hive-Transaktionen konnten nicht geladen werden</string>
+    <string name="hive_transactions_empty">Keine finanziellen Transaktionen gefunden</string>
+    <string name="load_more_lbl">Mehr laden</string>
 </resources>
+
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -739,5 +739,17 @@
     <string name="profile_companion_picker_title">Elige tu animal espiritual</string>
     <string name="profile_streak_at_risk">⚠️ Te faltan %1$s pasos hoy para mantener tu racha de %2$d días</string>
     <string name="profile_metrics_legend">🚶 %1$s pasos · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="dhf_vote_title">Apoya nuestro trabajo 💪</string>
+    <string name="dhf_vote_message">Un voto con un solo toque en nuestra propuesta ayuda a apoyar nuestro trabajo continuo en Hive — y no te cuesta nada.</string>
+    <string name="dhf_vote_btn_hivesigner">Vota en 1 toque (Hivesigner)</string>
+    <string name="dhf_vote_btn_peakd">Lee y vota (PeakD)</string>
+    <string name="dhf_vote_btn_later">Quizás más tarde</string>
+    <string name="dhf_vote_btn_vote_now">Votar ahora</string>
+    <string name="dhf_vote_thanks">¡Gracias por apoyar a Actifit! 🙏</string>
+    <string name="hive_transactions_lbl">Transacciones de Hive</string>
+    <string name="hive_transactions_error">No se pudieron cargar las transacciones de Hive</string>
+    <string name="hive_transactions_empty">No se encontraron transacciones financieras</string>
+    <string name="load_more_lbl">Cargar más</string>
 </resources>
+
 

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -736,5 +736,17 @@
     <string name="profile_companion_picker_title">अपना आत्मिक पशु चुनें</string>
     <string name="profile_streak_at_risk">⚠️ अपनी %2$d-दिन की श्रृंखला बनाए रखने के लिए आज %1$s कदम बाकी हैं</string>
     <string name="profile_metrics_legend">🚶 %1$s कदम · 📏 %2$s किमी · 🔥 %3$s कैलोरी</string>
+    <string name="dhf_vote_title">हमारे काम का समर्थन करें 💪</string>
+    <string name="dhf_vote_message">हमारे प्रस्ताव पर एक टैप में वोट देने से Hive पर हमारे चल रहे काम को समर्थन मिलता है — और इसका आपको कोई खर्च नहीं आता।</string>
+    <string name="dhf_vote_btn_hivesigner">1 टैप में वोट करें (Hivesigner)</string>
+    <string name="dhf_vote_btn_peakd">पढ़ें और वोट करें (PeakD)</string>
+    <string name="dhf_vote_btn_later">शायद बाद में</string>
+    <string name="dhf_vote_btn_vote_now">अभी वोट करें</string>
+    <string name="dhf_vote_thanks">Actifit का समर्थन करने के लिए धन्यवाद! 🙏</string>
+    <string name="hive_transactions_lbl">Hive लेनदेन</string>
+    <string name="hive_transactions_error">Hive लेनदेन लोड नहीं हो सके</string>
+    <string name="hive_transactions_empty">कोई वित्तीय लेनदेन नहीं मिला</string>
+    <string name="load_more_lbl">और लोड करें</string>
 </resources>
+
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -736,5 +736,16 @@
     <string name="profile_companion_picker_title">Scegli il tuo animale guida</string>
     <string name="profile_streak_at_risk">⚠️ Ti mancano %1$s passi oggi per mantenere la tua serie di %2$d giorni</string>
     <string name="profile_metrics_legend">🚶 %1$s passi · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="dhf_vote_title">Sostieni il nostro lavoro 💪</string>
+    <string name="dhf_vote_message">Un voto con un tocco sulla nostra proposta aiuta a sostenere il nostro lavoro continuo su Hive — e non ti costa nulla.</string>
+    <string name="dhf_vote_btn_hivesigner">Vota in 1 tocco (Hivesigner)</string>
+    <string name="dhf_vote_btn_peakd">Leggi e vota (PeakD)</string>
+    <string name="dhf_vote_btn_later">Forse più tardi</string>
+    <string name="dhf_vote_btn_vote_now">Vota ora</string>
+    <string name="dhf_vote_thanks">Grazie per aver sostenuto Actifit! 🙏</string>
+    <string name="hive_transactions_lbl">Transazioni Hive</string>
+    <string name="hive_transactions_error">Impossibile caricare le transazioni Hive</string>
+    <string name="hive_transactions_empty">Nessuna transazione finanziaria trovata</string>
+    <string name="load_more_lbl">Carica altro</string>
 </resources>
 

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -736,5 +736,17 @@
     <string name="profile_companion_picker_title">수호 동물 선택</string>
     <string name="profile_streak_at_risk">⚠️ %2$d일 연속 기록을 유지하려면 오늘 %1$s걸음 남았습니다</string>
     <string name="profile_metrics_legend">🚶 %1$s걸음 · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="dhf_vote_title">저희 활동을 응원해 주세요 💪</string>
+    <string name="dhf_vote_message">저희 제안에 한 번의 탭으로 투표하시면 Hive에서 계속되는 저희 활동을 지원하는 데 도움이 됩니다 — 비용은 전혀 들지 않습니다.</string>
+    <string name="dhf_vote_btn_hivesigner">한 번의 탭으로 투표 (Hivesigner)</string>
+    <string name="dhf_vote_btn_peakd">읽고 투표하기 (PeakD)</string>
+    <string name="dhf_vote_btn_later">나중에</string>
+    <string name="dhf_vote_btn_vote_now">지금 투표하기</string>
+    <string name="dhf_vote_thanks">Actifit를 응원해 주셔서 감사합니다! 🙏</string>
+    <string name="hive_transactions_lbl">Hive 거래 내역</string>
+    <string name="hive_transactions_error">Hive 거래 내역을 불러올 수 없습니다</string>
+    <string name="hive_transactions_empty">금융 거래 내역이 없습니다</string>
+    <string name="load_more_lbl">더 보기</string>
 </resources>
+
 

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -736,5 +736,17 @@
     <string name="profile_companion_picker_title">Kies je totemdier</string>
     <string name="profile_streak_at_risk">⚠️ Nog %1$s stappen vandaag om je reeks van %2$d dagen te behouden</string>
     <string name="profile_metrics_legend">🚶 %1$s stappen · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="dhf_vote_title">Steun ons werk 💪</string>
+    <string name="dhf_vote_message">Een stem met één tik op ons voorstel helpt ons voortdurende werk op Hive te ondersteunen — en het kost je niets.</string>
+    <string name="dhf_vote_btn_hivesigner">Stem in 1 tik (Hivesigner)</string>
+    <string name="dhf_vote_btn_peakd">Lees &amp; stem (PeakD)</string>
+    <string name="dhf_vote_btn_later">Misschien later</string>
+    <string name="dhf_vote_btn_vote_now">Nu stemmen</string>
+    <string name="dhf_vote_thanks">Bedankt voor je steun aan Actifit! 🙏</string>
+    <string name="hive_transactions_lbl">Hive-transacties</string>
+    <string name="hive_transactions_error">Hive-transacties konden niet worden geladen</string>
+    <string name="hive_transactions_empty">Geen financiële transacties gevonden</string>
+    <string name="load_more_lbl">Meer laden</string>
 </resources>
+
 

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -736,6 +736,18 @@
     <string name="profile_companion_picker_title">Escolha seu animal espiritual</string>
     <string name="profile_streak_at_risk">⚠️ Faltam %1$s passos hoje para manter sua sequência de %2$d dias</string>
     <string name="profile_metrics_legend">🚶 %1$s passos · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="dhf_vote_title">Apoie nosso trabalho 💪</string>
+    <string name="dhf_vote_message">Um voto com um toque na nossa proposta ajuda a apoiar nosso trabalho contínuo na Hive — e não custa nada para você.</string>
+    <string name="dhf_vote_btn_hivesigner">Vote em 1 toque (Hivesigner)</string>
+    <string name="dhf_vote_btn_peakd">Leia e vote (PeakD)</string>
+    <string name="dhf_vote_btn_later">Talvez mais tarde</string>
+    <string name="dhf_vote_btn_vote_now">Votar agora</string>
+    <string name="dhf_vote_thanks">Obrigado por apoiar o Actifit! 🙏</string>
+    <string name="hive_transactions_lbl">Transações Hive</string>
+    <string name="hive_transactions_error">Não foi possível carregar as transações Hive</string>
+    <string name="hive_transactions_empty">Nenhuma transação financeira encontrada</string>
+    <string name="load_more_lbl">Carregar mais</string>
 </resources>
+
 
 

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -736,5 +736,17 @@
     <string name="profile_companion_picker_title">Escolhe o teu animal espiritual</string>
     <string name="profile_streak_at_risk">⚠️ Faltam %1$s passos hoje para manteres a tua sequência de %2$d dias</string>
     <string name="profile_metrics_legend">🚶 %1$s passos · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="dhf_vote_title">Apoie o nosso trabalho 💪</string>
+    <string name="dhf_vote_message">Um voto com um toque na nossa proposta ajuda a apoiar o nosso trabalho contínuo na Hive — e não lhe custa nada.</string>
+    <string name="dhf_vote_btn_hivesigner">Vote em 1 toque (Hivesigner)</string>
+    <string name="dhf_vote_btn_peakd">Leia e vote (PeakD)</string>
+    <string name="dhf_vote_btn_later">Talvez mais tarde</string>
+    <string name="dhf_vote_btn_vote_now">Votar agora</string>
+    <string name="dhf_vote_thanks">Obrigado por apoiar a Actifit! 🙏</string>
+    <string name="hive_transactions_lbl">Transações Hive</string>
+    <string name="hive_transactions_error">Não foi possível carregar as transações Hive</string>
+    <string name="hive_transactions_empty">Nenhuma transação financeira encontrada</string>
+    <string name="load_more_lbl">Carregar mais</string>
 </resources>
+
 

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -735,4 +735,16 @@
     <string name="profile_companion_picker_title">Ruh hayvanını seç</string>
     <string name="profile_streak_at_risk">⚠️ %2$d günlük serini korumak için bugün %1$s adım kaldı</string>
     <string name="profile_metrics_legend">🚶 %1$s adım · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="dhf_vote_title">Çalışmamızı destekleyin 💪</string>
+    <string name="dhf_vote_message">Teklifimize tek dokunuşla oy vermek, Hive üzerindeki sürekli çalışmamızı desteklemenize yardımcı olur — ve size hiçbir maliyeti yoktur.</string>
+    <string name="dhf_vote_btn_hivesigner">1 dokunuşla oy verin (Hivesigner)</string>
+    <string name="dhf_vote_btn_peakd">Okuyun ve oy verin (PeakD)</string>
+    <string name="dhf_vote_btn_later">Belki sonra</string>
+    <string name="dhf_vote_btn_vote_now">Şimdi oy ver</string>
+    <string name="dhf_vote_thanks">Actifit\'i desteklediğiniz için teşekkürler! 🙏</string>
+    <string name="hive_transactions_lbl">Hive İşlemleri</string>
+    <string name="hive_transactions_error">Hive işlemleri yüklenemedi</string>
+    <string name="hive_transactions_empty">Hiçbir finansal işlem bulunamadı</string>
+    <string name="load_more_lbl">Daha Fazla Yükle</string>
 </resources>
+

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -735,5 +735,17 @@
     <string name="profile_companion_picker_title">Обери свою тварину-духа</string>
     <string name="profile_streak_at_risk">⚠️ Ще %1$s кроків сьогодні, щоб зберегти серію з %2$d днів</string>
     <string name="profile_metrics_legend">🚶 %1$s кроків · 📏 %2$s км · 🔥 %3$s ккал</string>
+    <string name="dhf_vote_title">Підтримайте нашу роботу 💪</string>
+    <string name="dhf_vote_message">Голосування в один дотик за нашу пропозицію допомагає підтримувати нашу постійну роботу на Hive — і це не коштує вам нічого.</string>
+    <string name="dhf_vote_btn_hivesigner">Проголосувати в 1 дотик (Hivesigner)</string>
+    <string name="dhf_vote_btn_peakd">Прочитати та проголосувати (PeakD)</string>
+    <string name="dhf_vote_btn_later">Можливо пізніше</string>
+    <string name="dhf_vote_btn_vote_now">Голосувати зараз</string>
+    <string name="dhf_vote_thanks">Дякуємо за підтримку Actifit! 🙏</string>
+    <string name="hive_transactions_lbl">Транзакції Hive</string>
+    <string name="hive_transactions_error">Не вдалося завантажити транзакції Hive</string>
+    <string name="hive_transactions_empty">Фінансових транзакцій не знайдено</string>
+    <string name="load_more_lbl">Завантажити більше</string>
 </resources>
+
 

--- a/app/src/main/res/values-yo/strings.xml
+++ b/app/src/main/res/values-yo/strings.xml
@@ -736,5 +736,17 @@
     <string name="profile_companion_picker_title">Yan ẹranko ẹ̀mí rẹ</string>
     <string name="profile_streak_at_risk">⚠️ %1$s ìṣísẹ̀ ló kù lónìí láti pa ọ̀wọ́ ọjọ́ %2$d rẹ mọ́</string>
     <string name="profile_metrics_legend">🚶 %1$s ìṣísẹ̀ · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="dhf_vote_title">Ṣe àtìlẹyìn iṣẹ́ wa 💪</string>
+    <string name="dhf_vote_message">Ìdìbò kan pẹ̀lú ìfọwọ́kàn kan lórí ìdábàá wa ń ràn wá lọ́wọ́ láti ṣe àtìlẹyìn iṣẹ́ wa tí ń lọ lórí Hive — kò sì ná ọ ohunkóhun.</string>
+    <string name="dhf_vote_btn_hivesigner">Dìbò ní ìfọwọ́kàn 1 (Hivesigner)</string>
+    <string name="dhf_vote_btn_peakd">Ka àti dìbò (PeakD)</string>
+    <string name="dhf_vote_btn_later">Bóyá nígbà mìíràn</string>
+    <string name="dhf_vote_btn_vote_now">Dìbò nísinsìnyí</string>
+    <string name="dhf_vote_thanks">A dúpẹ́ fún àtìlẹyìn Actifit! 🙏</string>
+    <string name="hive_transactions_lbl">Ìṣòwò Hive</string>
+    <string name="hive_transactions_error">A kò lè gbé ìṣòwò Hive wọlé</string>
+    <string name="hive_transactions_empty">A kò rí ìṣòwò owó kankan</string>
+    <string name="load_more_lbl">Gbé sí i wọlé</string>
 </resources>
+
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -735,4 +735,16 @@
     <string name="profile_companion_picker_title">选择你的灵兽</string>
     <string name="profile_streak_at_risk">⚠️ 今天还差 %1$s 步即可保持你的 %2$d 天连续记录</string>
     <string name="profile_metrics_legend">🚶 %1$s 步 · 📏 %2$s 公里 · 🔥 %3$s 千卡</string>
+    <string name="dhf_vote_title">支持我们的工作 💪</string>
+    <string name="dhf_vote_message">为我们的提案投上一票，只需轻轻一点，就能支持我们在 Hive 上持续开展的工作——而且完全免费。</string>
+    <string name="dhf_vote_btn_hivesigner">一键投票 (Hivesigner)</string>
+    <string name="dhf_vote_btn_peakd">阅读并投票 (PeakD)</string>
+    <string name="dhf_vote_btn_later">以后再说</string>
+    <string name="dhf_vote_btn_vote_now">立即投票</string>
+    <string name="dhf_vote_thanks">感谢您支持 Actifit！🙏</string>
+    <string name="hive_transactions_lbl">Hive 交易记录</string>
+    <string name="hive_transactions_error">无法加载 Hive 交易记录</string>
+    <string name="hive_transactions_empty">未找到任何财务交易记录</string>
+    <string name="load_more_lbl">加载更多</string>
 </resources>
+


### PR DESCRIPTION
## What this does
Adds translations for 11 strings that were present in English (`values/strings.xml`) but missing across all 13 locale files: the DHF proposal vote prompt (`dhf_vote_title`, `dhf_vote_message`, `dhf_vote_thanks`, + 4 button labels) and Hive transactions strings (`hive_transactions_lbl`, `hive_transactions_error`, `hive_transactions_empty`, `load_more_lbl`).

## Note on branch history
This replaces PR #74, which was accidentally branched off `feature/ai-post-screen` and so carried the entire AI-popup diff. This branch was cut fresh from a clean `develop` and cherry-picked to contain **only** the translation changes — no AI-popup files in the diff. Will close #74 in favor of this one.

## Notes
- Fixed an unescaped apostrophe in the Turkish translation (`Actifit'i` → `Actifit\'i`)
- Flagging `yo` (Yoruba) as not native-speaker verified
- Confirmed via `.\gradlew.bat assembleDebug` — build succeeds