### PR TITLE
feat: convert More menu items to string resources and translate acros…

### DIFF
--- a/app/src/main/res/layout/bottom_sheet_more_menu.xml
+++ b/app/src/main/res/layout/bottom_sheet_more_menu.xml
@@ -25,11 +25,10 @@
         android:paddingEnd="20dp"
         android:paddingTop="4dp"
         android:paddingBottom="12dp"
-        android:text="More"
+        android:text="@string/more_menu_title"
         android:textSize="16sp"
         android:textStyle="bold"
-        android:textColor="@color/md_theme_primary"
-        tools:ignore="HardcodedText" />
+        android:textColor="@color/md_theme_primary" />
 
     <!-- Divider -->
     <View
@@ -65,8 +64,7 @@
             android:layout_height="wrap_content"
             android:paddingStart="16dp"
             android:textSize="15sp"
-            android:text="Activity History"
-            tools:ignore="HardcodedText" />
+            android:text="@string/more_menu_activity_history" />
     </LinearLayout>
 
     <!-- Videos -->
@@ -96,8 +94,7 @@
             android:layout_height="wrap_content"
             android:paddingStart="16dp"
             android:textSize="15sp"
-            android:text="Upload Video"
-            tools:ignore="HardcodedText" />
+            android:text="@string/more_menu_upload_video" />
     </LinearLayout>
 
     <!-- Socials -->
@@ -127,8 +124,7 @@
             android:layout_height="wrap_content"
             android:paddingStart="16dp"
             android:textSize="15sp"
-            android:text="Follow Us"
-            tools:ignore="HardcodedText" />
+            android:text="@string/more_menu_follow_us" />
     </LinearLayout>
 
     <!-- Help -->
@@ -158,8 +154,7 @@
             android:layout_height="wrap_content"
             android:paddingStart="16dp"
             android:textSize="15sp"
-            android:text="Help &amp; FAQ"
-            tools:ignore="HardcodedText" />
+            android:text="@string/more_menu_help_faq" />
     </LinearLayout>
 
     <!-- Chat -->
@@ -189,8 +184,7 @@
             android:layout_height="wrap_content"
             android:paddingStart="16dp"
             android:textSize="15sp"
-            android:text="Community Chat"
-            tools:ignore="HardcodedText" />
+            android:text="@string/more_menu_community_chat" />
     </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -747,5 +747,11 @@
     <string name="profile_companion_picker_title">اختر حيوانك الروحي</string>
     <string name="profile_streak_at_risk">⚠️ بقيت %1$s خطوة اليوم للحفاظ على سلسلتك المكوّنة من %2$d يوم</string>
     <string name="profile_metrics_legend">🚶 %1$s خطوة · 📏 %2$s كم · 🔥 %3$s سعرة</string>
+    <string name="more_menu_title">المزيد</string>
+    <string name="more_menu_activity_history">سجل النشاط</string>
+    <string name="more_menu_upload_video">رفع فيديو</string>
+    <string name="more_menu_follow_us">تابعنا</string>
+    <string name="more_menu_help_faq">المساعدة والأسئلة الشائعة</string>
+    <string name="more_menu_community_chat">دردشة المجتمع</string>
 </resources>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -740,5 +740,11 @@
     <string name="profile_companion_picker_title">Wähle dein Krafttier</string>
     <string name="profile_streak_at_risk">⚠️ Noch %1$s Schritte heute, um deine %2$d-Tage-Serie zu erhalten</string>
     <string name="profile_metrics_legend">🚶 %1$s Schritte · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="more_menu_title">Mehr</string>
+    <string name="more_menu_activity_history">Aktivitätsverlauf</string>
+    <string name="more_menu_upload_video">Video hochladen</string>
+    <string name="more_menu_follow_us">Folge uns</string>
+    <string name="more_menu_help_faq">Hilfe &amp; FAQ</string>
+    <string name="more_menu_community_chat">Community-Chat</string>
 </resources>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -739,5 +739,11 @@
     <string name="profile_companion_picker_title">Elige tu animal espiritual</string>
     <string name="profile_streak_at_risk">⚠️ Te faltan %1$s pasos hoy para mantener tu racha de %2$d días</string>
     <string name="profile_metrics_legend">🚶 %1$s pasos · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="more_menu_title">Más</string>
+    <string name="more_menu_activity_history">Historial de actividad</string>
+    <string name="more_menu_upload_video">Subir video</string>
+    <string name="more_menu_follow_us">Síguenos</string>
+    <string name="more_menu_help_faq">Ayuda y preguntas frecuentes</string>
+    <string name="more_menu_community_chat">Chat de la comunidad</string>
 </resources>
 

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -736,5 +736,11 @@
     <string name="profile_companion_picker_title">अपना आत्मिक पशु चुनें</string>
     <string name="profile_streak_at_risk">⚠️ अपनी %2$d-दिन की श्रृंखला बनाए रखने के लिए आज %1$s कदम बाकी हैं</string>
     <string name="profile_metrics_legend">🚶 %1$s कदम · 📏 %2$s किमी · 🔥 %3$s कैलोरी</string>
+    <string name="more_menu_title">और अधिक</string>
+    <string name="more_menu_activity_history">गतिविधि इतिहास</string>
+    <string name="more_menu_upload_video">वीडियो अपलोड करें</string>
+    <string name="more_menu_follow_us">हमें फ़ॉलो करें</string>
+    <string name="more_menu_help_faq">सहायता और सामान्य प्रश्न</string>
+    <string name="more_menu_community_chat">समुदाय चैट</string>
 </resources>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -736,5 +736,11 @@
     <string name="profile_companion_picker_title">Scegli il tuo animale guida</string>
     <string name="profile_streak_at_risk">⚠️ Ti mancano %1$s passi oggi per mantenere la tua serie di %2$d giorni</string>
     <string name="profile_metrics_legend">🚶 %1$s passi · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="more_menu_title">Altro</string>
+    <string name="more_menu_activity_history">Cronologia attività</string>
+    <string name="more_menu_upload_video">Carica video</string>
+    <string name="more_menu_follow_us">Seguici</string>
+    <string name="more_menu_help_faq">Aiuto e FAQ</string>
+    <string name="more_menu_community_chat">Chat della community</string>
 </resources>
 

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -736,5 +736,11 @@
     <string name="profile_companion_picker_title">수호 동물 선택</string>
     <string name="profile_streak_at_risk">⚠️ %2$d일 연속 기록을 유지하려면 오늘 %1$s걸음 남았습니다</string>
     <string name="profile_metrics_legend">🚶 %1$s걸음 · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="more_menu_title">더보기</string>
+    <string name="more_menu_activity_history">활동 기록</string>
+    <string name="more_menu_upload_video">동영상 업로드</string>
+    <string name="more_menu_follow_us">팔로우하기</string>
+    <string name="more_menu_help_faq">도움말 및 FAQ</string>
+    <string name="more_menu_community_chat">커뮤니티 채팅</string>
 </resources>
 

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -736,5 +736,11 @@
     <string name="profile_companion_picker_title">Kies je totemdier</string>
     <string name="profile_streak_at_risk">⚠️ Nog %1$s stappen vandaag om je reeks van %2$d dagen te behouden</string>
     <string name="profile_metrics_legend">🚶 %1$s stappen · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="more_menu_title">Meer</string>
+    <string name="more_menu_activity_history">Activiteitengeschiedenis</string>
+    <string name="more_menu_upload_video">Video uploaden</string>
+    <string name="more_menu_follow_us">Volg ons</string>
+    <string name="more_menu_help_faq">Help &amp; FAQ</string>
+    <string name="more_menu_community_chat">Community chat</string>
 </resources>
 

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -736,6 +736,12 @@
     <string name="profile_companion_picker_title">Escolha seu animal espiritual</string>
     <string name="profile_streak_at_risk">⚠️ Faltam %1$s passos hoje para manter sua sequência de %2$d dias</string>
     <string name="profile_metrics_legend">🚶 %1$s passos · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="more_menu_title">Mais</string>
+    <string name="more_menu_activity_history">Histórico de atividade</string>
+    <string name="more_menu_upload_video">Enviar vídeo</string>
+    <string name="more_menu_follow_us">Siga-nos</string>
+    <string name="more_menu_help_faq">Ajuda e Perguntas Frequentes</string>
+    <string name="more_menu_community_chat">Chat da comunidade</string>
 </resources>
 
 

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -736,5 +736,11 @@
     <string name="profile_companion_picker_title">Escolhe o teu animal espiritual</string>
     <string name="profile_streak_at_risk">⚠️ Faltam %1$s passos hoje para manteres a tua sequência de %2$d dias</string>
     <string name="profile_metrics_legend">🚶 %1$s passos · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="more_menu_title">Mais</string>
+    <string name="more_menu_activity_history">Histórico de atividade</string>
+    <string name="more_menu_upload_video">Carregar vídeo</string>
+    <string name="more_menu_follow_us">Siga-nos</string>
+    <string name="more_menu_help_faq">Ajuda e FAQ</string>
+    <string name="more_menu_community_chat">Chat da comunidade</string>
 </resources>
 

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -735,4 +735,10 @@
     <string name="profile_companion_picker_title">Ruh hayvanını seç</string>
     <string name="profile_streak_at_risk">⚠️ %2$d günlük serini korumak için bugün %1$s adım kaldı</string>
     <string name="profile_metrics_legend">🚶 %1$s adım · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="more_menu_title">Daha Fazla</string>
+    <string name="more_menu_activity_history">Etkinlik Geçmişi</string>
+    <string name="more_menu_upload_video">Video Yükle</string>
+    <string name="more_menu_follow_us">Bizi Takip Edin</string>
+    <string name="more_menu_help_faq">Yardım ve SSS</string>
+    <string name="more_menu_community_chat">Topluluk Sohbeti</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -735,5 +735,11 @@
     <string name="profile_companion_picker_title">Обери свою тварину-духа</string>
     <string name="profile_streak_at_risk">⚠️ Ще %1$s кроків сьогодні, щоб зберегти серію з %2$d днів</string>
     <string name="profile_metrics_legend">🚶 %1$s кроків · 📏 %2$s км · 🔥 %3$s ккал</string>
+    <string name="more_menu_title">Більше</string>
+    <string name="more_menu_activity_history">Історія активності</string>
+    <string name="more_menu_upload_video">Завантажити відео</string>
+    <string name="more_menu_follow_us">Слідкуйте за нами</string>
+    <string name="more_menu_help_faq">Допомога та поширені запитання</string>
+    <string name="more_menu_community_chat">Чат спільноти</string>
 </resources>
 

--- a/app/src/main/res/values-yo/strings.xml
+++ b/app/src/main/res/values-yo/strings.xml
@@ -736,5 +736,11 @@
     <string name="profile_companion_picker_title">Yan ẹranko ẹ̀mí rẹ</string>
     <string name="profile_streak_at_risk">⚠️ %1$s ìṣísẹ̀ ló kù lónìí láti pa ọ̀wọ́ ọjọ́ %2$d rẹ mọ́</string>
     <string name="profile_metrics_legend">🚶 %1$s ìṣísẹ̀ · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="more_menu_title">Síwájú sí i</string>
+    <string name="more_menu_activity_history">Ìtàn Iṣẹ́ Ṣíṣe</string>
+    <string name="more_menu_upload_video">Gbé fídíò sókè</string>
+    <string name="more_menu_follow_us">Tẹ̀ lé wa</string>
+    <string name="more_menu_help_faq">Ìrànlọ́wọ́ àti Àwọn Ìbéèrè Tí A Sábà Ń Béèrè</string>
+    <string name="more_menu_community_chat">Ìjíròrò Àwùjọ</string>
 </resources>
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -735,4 +735,10 @@
     <string name="profile_companion_picker_title">选择你的灵兽</string>
     <string name="profile_streak_at_risk">⚠️ 今天还差 %1$s 步即可保持你的 %2$d 天连续记录</string>
     <string name="profile_metrics_legend">🚶 %1$s 步 · 📏 %2$s 公里 · 🔥 %3$s 千卡</string>
+    <string name="more_menu_title">更多</string>
+    <string name="more_menu_activity_history">活动历史</string>
+    <string name="more_menu_upload_video">上传视频</string>
+    <string name="more_menu_follow_us">关注我们</string>
+    <string name="more_menu_help_faq">帮助与常见问题</string>
+    <string name="more_menu_community_chat">社区聊天</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -731,4 +731,10 @@
     <string name="dhf_vote_btn_later">Maybe later</string>
     <string name="dhf_vote_btn_vote_now">Vote now</string>
     <string name="dhf_vote_thanks">Thanks for supporting Actifit! 🙏</string>
+    <string name="more_menu_title">More</string>
+    <string name="more_menu_activity_history">Activity History</string>
+    <string name="more_menu_upload_video">Upload Video</string>
+    <string name="more_menu_follow_us">Follow Us</string>
+    <string name="more_menu_help_faq">Help &amp; FAQ</string>
+    <string name="more_menu_community_chat">Community Chat</string>
 </resources>


### PR DESCRIPTION
## What this does
Fixes the hardcoded English text in the "More" bottom sheet menu (`bottom_sheet_more_menu.xml`). The 6 items — "More" (title), "Activity History", "Upload Video", "Follow Us", "Help & FAQ", "Community Chat" — were hardcoded directly with `tools:ignore="HardcodedText"` suppressing the lint warning, which is why they never surfaced as missing translations.

## Changes
- Added 6 new string resources to `values/strings.xml`
- Updated `bottom_sheet_more_menu.xml` to reference `@string/more_menu_*` instead of hardcoded text
- Removed all 6 `tools:ignore="HardcodedText"` suppressions
- Translated all 6 strings across all 13 locales

## Scope
Branched fresh from up-to-date `develop`, per feedback on #74/#75. Only touches the layout file + string resource files — no AI-popup or DHF/Hive-strings work included.

## Notes
- Flagging `yo` (Yoruba) as not native-speaker verified
- Confirmed via `.\gradlew.bat assembleDebug` — build succeeds