### PR TITLE
Fix distance/pace ignoring US measurement-system setting

### DIFF
--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
@@ -3052,7 +3052,7 @@ public class MainActivity extends BaseActivity {
         View fullContent = findViewById(R.id.route_full_content);
         if (summary == null || tvInfo == null) return;
         if (route != null) {
-            tvInfo.setText(route.getFormattedDistance() + "  •  " + route.getFormattedDuration()
+            tvInfo.setText(route.getFormattedDistance(this) + "  •  " + route.getFormattedDuration()
                     + "  •  " + (route.activityType != null ? route.activityType : ""));
             summary.setVisibility(View.VISIBLE);
             if (fullContent != null) fullContent.setVisibility(View.VISIBLE);

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/ProfileActivity.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/ProfileActivity.java
@@ -220,9 +220,13 @@ public class ProfileActivity extends BaseActivity {
         auraStepsFrac = steps / (float) DAILY_GOAL;
         auraDistFrac = distKm / DIST_GOAL_KM;
         auraCalFrac = cal / CAL_GOAL;
+        // honor the user's measurement system (metric km / US miles) for the legend distance
+        boolean metric = Utils.isMetricSystem(this);
+        float distDisplay = metric ? distKm : distKm / 1.609344f;
+        String distToken = String.format(Locale.getDefault(), "%.1f %s", distDisplay, metric ? "km" : "mi");
         metricsLegend.setText(getString(R.string.profile_metrics_legend,
                 compact(steps),
-                String.format(Locale.getDefault(), "%.1f", distKm),
+                distToken,
                 String.valueOf(Math.round(cal))));
     }
 

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/RouteMapActivity.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/RouteMapActivity.java
@@ -186,9 +186,9 @@ public class RouteMapActivity extends BaseActivity {
         }
 
         tvActivityLabel.setText(route.activityType != null ? route.activityType : "Activity");
-        tvDistance.setText(route.getFormattedDistance());
+        tvDistance.setText(route.getFormattedDistance(this));
         tvDuration.setText(route.getFormattedDuration());
-        tvPace.setText(route.getFormattedPace());
+        tvPace.setText(route.getFormattedPace(this));
 
         tvSteps.setText("--"); // day total ≠ route steps; no per-route step data available
 
@@ -224,15 +224,12 @@ public class RouteMapActivity extends BaseActivity {
     }
 
     private void updateLiveStats(double distanceMeters, long durationMs) {
-        tvDistance.setText(String.format(Locale.getDefault(), "%.2f km", distanceMeters / 1000.0));
+        tvDistance.setText(Utils.formatDistance(this, distanceMeters));
         long min = TimeUnit.MILLISECONDS.toMinutes(durationMs);
         long sec = TimeUnit.MILLISECONDS.toSeconds(durationMs) % 60;
         tvDuration.setText(String.format(Locale.getDefault(), "%d:%02d", min, sec));
         if (distanceMeters > 50) {
-            double secPerKm = (durationMs / 1000.0) / (distanceMeters / 1000.0);
-            long paceMin = (long) secPerKm / 60;
-            long paceSec = (long) secPerKm % 60;
-            tvPace.setText(String.format(Locale.getDefault(), "%d:%02d/km", paceMin, paceSec));
+            tvPace.setText(Utils.formatPace(this, distanceMeters, durationMs));
         }
     }
 

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/RouteModel.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/RouteModel.java
@@ -1,5 +1,7 @@
 package io.actifit.fitnesstracker.actifitfitnesstracker;
 
+import android.content.Context;
+
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
@@ -29,11 +31,9 @@ public class RouteModel {
         return endTimeMs - startTimeMs;
     }
 
-    public String getFormattedDistance() {
-        if (distanceMeters < 1000) {
-            return String.format(Locale.getDefault(), "%.0f m", distanceMeters);
-        }
-        return String.format(Locale.getDefault(), "%.2f km", distanceMeters / 1000.0);
+    /** Formats distance honoring the user's active measurement system (metric km / US miles). */
+    public String getFormattedDistance(Context context) {
+        return Utils.formatDistance(context, distanceMeters);
     }
 
     public String getFormattedDuration() {
@@ -47,14 +47,8 @@ public class RouteModel {
         return String.format(Locale.getDefault(), "%d:%02d", minutes, seconds);
     }
 
-    /** Returns avg pace as min/km string, e.g. "7:07/km". Returns "" if no movement. */
-    public String getFormattedPace() {
-        long durationSec = TimeUnit.MILLISECONDS.toSeconds(getDurationMs());
-        double distKm = distanceMeters / 1000.0;
-        if (distKm < 0.01 || durationSec == 0) return "--";
-        double secPerKm = durationSec / distKm;
-        long paceMin = (long) secPerKm / 60;
-        long paceSec = (long) secPerKm % 60;
-        return String.format(Locale.getDefault(), "%d:%02d/km", paceMin, paceSec);
+    /** Returns avg pace (min/km or min/mi per the user's setting), e.g. "7:07/km". "--" if no movement. */
+    public String getFormattedPace(Context context) {
+        return Utils.formatPace(context, distanceMeters, getDurationMs());
     }
 }

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/RouteRecordingService.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/RouteRecordingService.java
@@ -110,7 +110,7 @@ public class RouteRecordingService extends Service {
         totalDistanceMeters = 0;
         lastLocation = null;
 
-        startForeground(NOTIFICATION_ID, buildNotification("0.00 km", "00:00"));
+        startForeground(NOTIFICATION_ID, buildNotification(Utils.formatDistance(this, 0), "00:00"));
 
         LocationRequest locationRequest = new LocationRequest.Builder(
                 Priority.PRIORITY_HIGH_ACCURACY, 3000)
@@ -189,7 +189,7 @@ public class RouteRecordingService extends Service {
     }
 
     private void updateNotification(double distanceMeters, long durationMs) {
-        String distStr = String.format(Locale.getDefault(), "%.2f km", distanceMeters / 1000.0);
+        String distStr = Utils.formatDistance(this, distanceMeters);
         long min = TimeUnit.MILLISECONDS.toMinutes(durationMs);
         long sec = TimeUnit.MILLISECONDS.toSeconds(durationMs) % 60;
         String timeStr = String.format(Locale.getDefault(), "%02d:%02d", min, sec);

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/Utils.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/Utils.java
@@ -64,6 +64,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
@@ -85,6 +86,55 @@ import androidx.exifinterface.media.ExifInterface;
     public class Utils {
 
         private static final String TAG = "Utils";
+
+        // --- Measurement-system helpers (distance / pace) ---
+
+        private static final double METERS_PER_MILE = 1609.344;
+
+        /**
+         * Reads the user's active measurement system from settings.
+         * Defaults to metric when unset.
+         *
+         * @return true if the user is on the metric (km) system, false for US/imperial (miles).
+         */
+        public static boolean isMetricSystem(Context context) {
+            SharedPreferences sharedPreferences = context.getSharedPreferences("actifitSets", MODE_PRIVATE);
+            String activeSystem = sharedPreferences.getString("activeSystem",
+                    context.getString(R.string.metric_system_ntt));
+            // anything other than an explicit US selection is treated as metric (matches SettingsActivity default)
+            return !activeSystem.equals(context.getString(R.string.us_system_ntt));
+        }
+
+        /**
+         * Formats a distance (given in meters) using the user's active measurement system.
+         * Metric: "850 m" / "3.24 km". US: "0.53 mi" (short distances also expressed in miles).
+         */
+        public static String formatDistance(Context context, double distanceMeters) {
+            if (isMetricSystem(context)) {
+                if (distanceMeters < 1000) {
+                    return String.format(Locale.getDefault(), "%.0f m", distanceMeters);
+                }
+                return String.format(Locale.getDefault(), "%.2f km", distanceMeters / 1000.0);
+            }
+            double miles = distanceMeters / METERS_PER_MILE;
+            return String.format(Locale.getDefault(), "%.2f mi", miles);
+        }
+
+        /**
+         * Formats average pace using the user's active measurement system.
+         * Metric: "7:07/km". US: "11:27/mi". Returns "--" when there is no meaningful movement.
+         */
+        public static String formatPace(Context context, double distanceMeters, long durationMs) {
+            long durationSec = durationMs / 1000;
+            if (distanceMeters < 10 || durationSec == 0) return "--";
+            boolean metric = isMetricSystem(context);
+            double unitDistance = metric ? distanceMeters / 1000.0 : distanceMeters / METERS_PER_MILE;
+            if (unitDistance <= 0) return "--";
+            double secPerUnit = durationSec / unitDistance;
+            long paceMin = (long) secPerUnit / 60;
+            long paceSec = (long) secPerUnit % 60;
+            return String.format(Locale.getDefault(), "%d:%02d/%s", paceMin, paceSec, metric ? "km" : "mi");
+        }
 
         // --- Your other Utils methods (uploadFile, etc.) ---
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -746,6 +746,6 @@
     <string name="profile_companion_hint">✎ تغيير الحيوان</string>
     <string name="profile_companion_picker_title">اختر حيوانك الروحي</string>
     <string name="profile_streak_at_risk">⚠️ بقيت %1$s خطوة اليوم للحفاظ على سلسلتك المكوّنة من %2$d يوم</string>
-    <string name="profile_metrics_legend">🚶 %1$s خطوة · 📏 %2$s كم · 🔥 %3$s سعرة</string>
+    <string name="profile_metrics_legend">🚶 %1$s خطوة · 📏 %2$s · 🔥 %3$s سعرة</string>
 </resources>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -739,6 +739,6 @@
     <string name="profile_companion_hint">✎ Tier ändern</string>
     <string name="profile_companion_picker_title">Wähle dein Krafttier</string>
     <string name="profile_streak_at_risk">⚠️ Noch %1$s Schritte heute, um deine %2$d-Tage-Serie zu erhalten</string>
-    <string name="profile_metrics_legend">🚶 %1$s Schritte · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="profile_metrics_legend">🚶 %1$s Schritte · 📏 %2$s · 🔥 %3$s kcal</string>
 </resources>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -738,6 +738,6 @@
     <string name="profile_companion_hint">✎ Cambiar animal</string>
     <string name="profile_companion_picker_title">Elige tu animal espiritual</string>
     <string name="profile_streak_at_risk">⚠️ Te faltan %1$s pasos hoy para mantener tu racha de %2$d días</string>
-    <string name="profile_metrics_legend">🚶 %1$s pasos · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="profile_metrics_legend">🚶 %1$s pasos · 📏 %2$s · 🔥 %3$s kcal</string>
 </resources>
 

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -735,6 +735,6 @@
     <string name="profile_companion_hint">✎ जानवर बदलें</string>
     <string name="profile_companion_picker_title">अपना आत्मिक पशु चुनें</string>
     <string name="profile_streak_at_risk">⚠️ अपनी %2$d-दिन की श्रृंखला बनाए रखने के लिए आज %1$s कदम बाकी हैं</string>
-    <string name="profile_metrics_legend">🚶 %1$s कदम · 📏 %2$s किमी · 🔥 %3$s कैलोरी</string>
+    <string name="profile_metrics_legend">🚶 %1$s कदम · 📏 %2$s · 🔥 %3$s कैलोरी</string>
 </resources>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -735,6 +735,6 @@
     <string name="profile_companion_hint">✎ Cambia animale</string>
     <string name="profile_companion_picker_title">Scegli il tuo animale guida</string>
     <string name="profile_streak_at_risk">⚠️ Ti mancano %1$s passi oggi per mantenere la tua serie di %2$d giorni</string>
-    <string name="profile_metrics_legend">🚶 %1$s passi · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="profile_metrics_legend">🚶 %1$s passi · 📏 %2$s · 🔥 %3$s kcal</string>
 </resources>
 

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -735,6 +735,6 @@
     <string name="profile_companion_hint">✎ 동물 변경</string>
     <string name="profile_companion_picker_title">수호 동물 선택</string>
     <string name="profile_streak_at_risk">⚠️ %2$d일 연속 기록을 유지하려면 오늘 %1$s걸음 남았습니다</string>
-    <string name="profile_metrics_legend">🚶 %1$s걸음 · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="profile_metrics_legend">🚶 %1$s걸음 · 📏 %2$s · 🔥 %3$s kcal</string>
 </resources>
 

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -735,6 +735,6 @@
     <string name="profile_companion_hint">✎ Dier wijzigen</string>
     <string name="profile_companion_picker_title">Kies je totemdier</string>
     <string name="profile_streak_at_risk">⚠️ Nog %1$s stappen vandaag om je reeks van %2$d dagen te behouden</string>
-    <string name="profile_metrics_legend">🚶 %1$s stappen · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="profile_metrics_legend">🚶 %1$s stappen · 📏 %2$s · 🔥 %3$s kcal</string>
 </resources>
 

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -735,7 +735,7 @@
     <string name="profile_companion_hint">✎ Trocar animal</string>
     <string name="profile_companion_picker_title">Escolha seu animal espiritual</string>
     <string name="profile_streak_at_risk">⚠️ Faltam %1$s passos hoje para manter sua sequência de %2$d dias</string>
-    <string name="profile_metrics_legend">🚶 %1$s passos · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="profile_metrics_legend">🚶 %1$s passos · 📏 %2$s · 🔥 %3$s kcal</string>
 </resources>
 
 

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -735,6 +735,6 @@
     <string name="profile_companion_hint">✎ Mudar animal</string>
     <string name="profile_companion_picker_title">Escolhe o teu animal espiritual</string>
     <string name="profile_streak_at_risk">⚠️ Faltam %1$s passos hoje para manteres a tua sequência de %2$d dias</string>
-    <string name="profile_metrics_legend">🚶 %1$s passos · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="profile_metrics_legend">🚶 %1$s passos · 📏 %2$s · 🔥 %3$s kcal</string>
 </resources>
 

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -734,5 +734,5 @@
     <string name="profile_companion_hint">✎ Hayvanı değiştir</string>
     <string name="profile_companion_picker_title">Ruh hayvanını seç</string>
     <string name="profile_streak_at_risk">⚠️ %2$d günlük serini korumak için bugün %1$s adım kaldı</string>
-    <string name="profile_metrics_legend">🚶 %1$s adım · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="profile_metrics_legend">🚶 %1$s adım · 📏 %2$s · 🔥 %3$s kcal</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -734,6 +734,6 @@
     <string name="profile_companion_hint">✎ Змінити тварину</string>
     <string name="profile_companion_picker_title">Обери свою тварину-духа</string>
     <string name="profile_streak_at_risk">⚠️ Ще %1$s кроків сьогодні, щоб зберегти серію з %2$d днів</string>
-    <string name="profile_metrics_legend">🚶 %1$s кроків · 📏 %2$s км · 🔥 %3$s ккал</string>
+    <string name="profile_metrics_legend">🚶 %1$s кроків · 📏 %2$s · 🔥 %3$s ккал</string>
 </resources>
 

--- a/app/src/main/res/values-yo/strings.xml
+++ b/app/src/main/res/values-yo/strings.xml
@@ -735,6 +735,6 @@
     <string name="profile_companion_hint">✎ Yí ẹranko padà</string>
     <string name="profile_companion_picker_title">Yan ẹranko ẹ̀mí rẹ</string>
     <string name="profile_streak_at_risk">⚠️ %1$s ìṣísẹ̀ ló kù lónìí láti pa ọ̀wọ́ ọjọ́ %2$d rẹ mọ́</string>
-    <string name="profile_metrics_legend">🚶 %1$s ìṣísẹ̀ · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="profile_metrics_legend">🚶 %1$s ìṣísẹ̀ · 📏 %2$s · 🔥 %3$s kcal</string>
 </resources>
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -734,5 +734,5 @@
     <string name="profile_companion_hint">✎ 更换动物</string>
     <string name="profile_companion_picker_title">选择你的灵兽</string>
     <string name="profile_streak_at_risk">⚠️ 今天还差 %1$s 步即可保持你的 %2$d 天连续记录</string>
-    <string name="profile_metrics_legend">🚶 %1$s 步 · 📏 %2$s 公里 · 🔥 %3$s 千卡</string>
+    <string name="profile_metrics_legend">🚶 %1$s 步 · 📏 %2$s · 🔥 %3$s 千卡</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,7 +19,7 @@
     <string name="profile_companion_picker_title">Choose your spirit animal</string>
     <string name="profile_tier_element" translatable="false">%1$s %2$s · %3$s</string>
     <string name="profile_streak_at_risk">⚠️ %1$s steps to go today to keep your %2$d-day streak alive</string>
-    <string name="profile_metrics_legend">🚶 %1$s steps · 📏 %2$s km · 🔥 %3$s kcal</string>
+    <string name="profile_metrics_legend">🚶 %1$s steps · 📏 %2$s · 🔥 %3$s kcal</string>
 
     <string name="sending_post">Sending your post...</string>
     <string name="success_post">Your post has been successfully submitted</string>


### PR DESCRIPTION
## Problem

Reported on the iOS app and confirmed present on Android: with **Settings → Measurement System = US System**, walk/route tracking still shows distance and pace in **metric** (km, min/km).

## Root cause

Distance/pace formatting was hardcoded as literal `"%.2f km"` / `".../km"` in several places, none of which read the stored `activeSystem` preference (`actifitSets` prefs).

## Fix

Centralized unit formatting in `Utils`:
- `Utils.isMetricSystem(context)` — reads `activeSystem` (defaults to metric, matching `SettingsActivity`)
- `Utils.formatDistance(context, meters)` — metric `m`/`km`, US `mi`
- `Utils.formatPace(context, meters, durationMs)` — `/km` or `/mi`

Routed every distance/pace display through these helpers:

| Surface | File |
|---|---|
| Live tracking stats + saved-route detail | `RouteMapActivity` |
| Foreground tracking notification (live + initial placeholder) | `RouteRecordingService` |
| `getFormattedDistance` / `getFormattedPace` (now take `Context`) | `RouteModel` |
| Dashboard "last route" summary | `MainActivity` |
| Activity-ring legend (same class of bug — always `km`) | `ProfileActivity` + 14 locale `strings.xml` |

For the profile legend, the unit was moved into the formatted value passed from Java and the hardcoded unit token stripped from all 14 translations, so US users see `mi` there too without breaking i18n.

Left unchanged: `MainActivity` `distKm` at the dashboard rings feeds only a unitless ring-fill fraction (`distKm / 8f`), never displayed as text, so no conversion needed.

## Testing

- `./gradlew compileDebugJavaWithJavac` passes (exit 0; only pre-existing Java 8 target/deprecation warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)