### PR TITLE
Drive security checks by build type; consolidate & harden enforcement

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,8 +39,8 @@ android {
         applicationId "io.actifit.fitnesstracker.actifitfitnesstracker"
         minSdkVersion 28
         targetSdkVersion 35
-        versionCode 64
-        versionName "v0.14.0"
+        versionCode 65
+        versionName "v0.14.1"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         multiDexEnabled true
     }
@@ -55,9 +55,11 @@ android {
                 }
             }
             buildConfigField("String", "GEMINI_API_KEY", "\"${getLocalProperty('gemini.api.key')}\"")
+            buildConfigField("boolean", "ENFORCE_SECURITY", resolveEnforceSecurity("true"))
         }
         debug {
             buildConfigField("String", "GEMINI_API_KEY", "\"${getLocalProperty('gemini.api.key')}\"")
+            buildConfigField("boolean", "ENFORCE_SECURITY", resolveEnforceSecurity("false"))
         }
     }
     buildFeatures{
@@ -80,6 +82,20 @@ def getLocalProperty(String propertyName) {
     }
 
     return properties.getProperty(propertyName)
+}
+
+// Resolves the security-enforcement switch for BuildConfig.ENFORCE_SECURITY.
+// Default follows the build type (release = "true", debug = "false"); a one-off
+// override can be set in local.properties / CI via: enforce.security=true|false
+def resolveEnforceSecurity(String defaultVal) {
+    def override = getLocalProperty('enforce.security')
+    if (override != null) {
+        override = override.trim().toLowerCase()
+        if (override == 'true' || override == 'false') {
+            return override
+        }
+    }
+    return defaultVal
 }
 
 dependencies {

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
@@ -147,7 +147,6 @@ import com.google.android.ump.UserMessagingPlatform;
 import com.google.firebase.iid.FirebaseInstanceId;
 import com.google.firebase.iid.InstanceIdResult;
 import com.google.firebase.messaging.FirebaseMessaging;
-import com.scottyab.rootbeer.RootBeer;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.json.JSONArray;
@@ -431,30 +430,6 @@ public class MainActivity extends BaseActivity {
         return image;
     }
 
-    // security function to detect emulators
-    public static boolean isEmulator() {
-        return Build.FINGERPRINT.contains("generic")
-                || Build.FINGERPRINT.startsWith("unknown")
-                || Build.MODEL.contains("google_sdk")
-                || Build.MODEL.contains("Emulator")
-                || Build.MODEL.contains("Android SDK built for x86")
-                || Build.MANUFACTURER.contains("Genymotion")
-                || (Build.BRAND.startsWith("generic")
-                && Build.DEVICE.startsWith("generic"))
-                || "google_sdk".equals(Build.PRODUCT)
-                || Build.HARDWARE.contains("goldfish")
-                || Build.HARDWARE.contains("ranchu")
-                || Build.HARDWARE.contains("andy");
-    }
-
-    private static final int VALID = 0;
-
-    private static final int INVALID = 1;
-
-    public int checkAppSignature(Context context) {
-        return securityManager.checkAppSignature() ? 0 : 1;
-    }
-
     // function handles killing the app
     private void killActifit(final String reason) {
         runOnUiThread(new Runnable() {
@@ -481,7 +456,9 @@ public class MainActivity extends BaseActivity {
                  */
 
                 toast.show();
-                finish();
+                // close the entire task, not just this activity, so a failed-integrity device
+                // cannot linger on a partially-initialized screen
+                finishAffinity();
                 /*
                  * System.exit(0);
                  * //kill gracefully after waiting for toast
@@ -505,11 +482,6 @@ public class MainActivity extends BaseActivity {
     protected void askPermissions(String[] permissions) {
         int requestCode = 200;
         requestPermissions(permissions, requestCode);
-    }
-
-    // function handles checking if the SIM card is available
-    public boolean isSimAvailable() {
-        return securityManager.isSimAvailable();
     }
 
     /*
@@ -4095,6 +4067,8 @@ public class MainActivity extends BaseActivity {
     private class PrepareGround extends AsyncTask<Void, Void, Void> {
         String dataTrackingSystem;
         int stepCount = 0;
+        // set when an integrity check fails so onPostExecute skips all dashboard initialization
+        boolean securityKilled = false;
 
         @Override
         protected Void doInBackground(Void... voids) {
@@ -4114,46 +4088,20 @@ public class MainActivity extends BaseActivity {
 
             /*************** security features ********************/
 
-            // check if signature has been tampered with
-
-            if (getString(R.string.sec_check_signature).equals("on")) {
-                if ((getString(R.string.test_mode).equals("off"))
-                        && checkAppSignature(ctx) == MainActivity.INVALID) {
-                    // package signature has been manipulated
-                    Log.d(TAG, ">>>>[Actifit] Package signature has been manipulated");
-                    killActifit(getString(R.string.security_concerns));
+            // Integrity checks (signature, package name, SIM, emulator, root) run only in
+            // enforcing builds — release by default, off for debug — via BuildConfig.ENFORCE_SECURITY
+            // (overridable through enforce.security in local.properties/CI). A failure halts
+            // initialization entirely: we mark the run as killed, stop this background pass, and
+            // onPostExecute() bails out before any dashboard work runs.
+            if (BuildConfig.ENFORCE_SECURITY) {
+                SecurityManager.SecurityResult secResult =
+                        securityManager.runSecurityChecks("io.actifit.fitnesstracker.actifitfitnesstracker");
+                if (!secResult.passed) {
+                    Log.d(TAG, ">>>>[Actifit] Security check failed: " + secResult.logTag);
+                    securityKilled = true;
+                    killActifit(getString(secResult.reasonResId));
+                    return null;
                 }
-
-                // make sure package name has not been manipulated
-                if (!ctx.getPackageName().equals("io.actifit.fitnesstracker.actifitfitnesstracker")) {
-                    // package name has been manipulated
-                    Log.d(TAG, ">>>>[Actifit] Package name has been manipulated");
-                    killActifit(getString(R.string.security_concerns));
-                }
-
-                // let's make sure this is a smart phone device by checking SIM Card
-
-                // Crashlytics.getInstance().crash();
-
-                if (!isSimAvailable()) {
-                    // no valid active sim card detected
-                    Log.d(TAG, ">>>>[Actifit] No valid SIM card detected");
-                    killActifit(getString(R.string.no_valid_sim));
-                }
-
-                // also let's try to detect if this is a known emulator
-                if (isEmulator()) {
-                    Log.d(TAG, ">>>>[Actifit] Emulator detected");
-                    killActifit(getString(R.string.emulator_device));
-                }
-
-                // check if device is rooted
-                RootBeer rootBeer = new RootBeer(ctx);
-                if (getString(R.string.test_mode).equals("off") && rootBeer.isRootedWithoutBusyBoxCheck()) {
-                    Log.d(TAG, ">>>>[Actifit] Device is rooted");
-                    killActifit(getString(R.string.device_rooted));
-                }
-
             }
             // require now for GDPR and ad display
             loadConsentData(false);
@@ -4211,6 +4159,11 @@ public class MainActivity extends BaseActivity {
         @Override
         protected void onPostExecute(Void param) {
             super.onPostExecute(param);
+            // an integrity check failed in doInBackground: the app is being torn down, so skip
+            // all dashboard initialization rather than rendering a screen we're about to close
+            if (securityKilled) {
+                return;
+            }
             final SharedPreferences sharedPreferences = getSharedPreferences("actifitSets",
                     MODE_PRIVATE);
             // display current date

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/RewardManager.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/RewardManager.java
@@ -141,7 +141,9 @@ public class RewardManager {
                             Log.d(TAG, loadAdError.toString());
                             rewardedAd = null;
                             isAdLoading = false;
-                            if (context.getString(R.string.sec_check_signature).equals("off")) {
+                            // non-enforcing (debug) builds surface the raw ad-load error to aid
+                            // diagnosis; enforcing (release) builds show a friendly message
+                            if (!BuildConfig.ENFORCE_SECURITY) {
                                 Toast.makeText(context, loadAdError.getMessage(), Toast.LENGTH_SHORT).show();
                             } else {
                                 Toast.makeText(context, context.getString(R.string.err_load_ad), Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/SecurityManager.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/SecurityManager.java
@@ -5,24 +5,27 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.Signature;
+import android.content.pm.SigningInfo;
 import android.os.Build;
 import android.telephony.TelephonyManager;
 import android.util.Base64;
-import android.widget.Toast;
 
 import com.scottyab.rootbeer.RootBeer;
 
 import java.security.MessageDigest;
 
 /**
- * Handles security and integrity checks: app signature validation,
- * emulator detection, root detection, and SIM card verification.
- * Extracted from MainActivity to reduce class size.
+ * Single source of truth for the app's integrity checks: app-signature validation,
+ * package-name validation, SIM presence, emulator detection and root detection.
+ *
+ * Enforcement is driven by {@code BuildConfig.ENFORCE_SECURITY} (release = on, debug = off,
+ * overridable via {@code enforce.security} in local.properties/CI) — NOT by a runtime string
+ * flag. Callers run {@link #runSecurityChecks(String)} only when enforcement is enabled and
+ * must halt the app when the returned result is not {@code passed}.
+ *
+ * All checks fail closed: any inability to positively verify integrity is treated as a failure.
  */
 public class SecurityManager {
-
-    private static final String VALID = "0";
-    private static final String INVALID = "1";
 
     private final Context context;
 
@@ -30,21 +33,86 @@ public class SecurityManager {
         this.context = context;
     }
 
+    /** Outcome of {@link #runSecurityChecks(String)}: pass, or the first failure and its reason. */
+    public static class SecurityResult {
+        public final boolean passed;
+        /** String resource shown to the user when {@code !passed}; 0 when passed. */
+        public final int reasonResId;
+        /** Internal label for logging; never shown to the user. */
+        public final String logTag;
+
+        private SecurityResult(boolean passed, int reasonResId, String logTag) {
+            this.passed = passed;
+            this.reasonResId = reasonResId;
+            this.logTag = logTag;
+        }
+
+        static SecurityResult pass() {
+            return new SecurityResult(true, 0, "ok");
+        }
+
+        static SecurityResult fail(int reasonResId, String logTag) {
+            return new SecurityResult(false, reasonResId, logTag);
+        }
+    }
+
+    /**
+     * Runs every integrity check in order and returns the first failure, or a passing result.
+     * Fails closed throughout.
+     *
+     * @param expectedPackageName the package name the release is expected to run under
+     */
+    public SecurityResult runSecurityChecks(String expectedPackageName) {
+        if (!checkAppSignature()) {
+            return SecurityResult.fail(R.string.security_concerns, "signature tampered");
+        }
+        if (!context.getPackageName().equals(expectedPackageName)) {
+            return SecurityResult.fail(R.string.security_concerns, "package name tampered");
+        }
+        if (!isSimAvailable()) {
+            return SecurityResult.fail(R.string.no_valid_sim, "no valid SIM");
+        }
+        if (isEmulator()) {
+            return SecurityResult.fail(R.string.emulator_device, "emulator detected");
+        }
+        if (isDeviceRooted()) {
+            return SecurityResult.fail(R.string.device_rooted, "device rooted");
+        }
+        return SecurityResult.pass();
+    }
+
+    /**
+     * Verifies the running APK is signed with the expected certificate.
+     * Uses the modern signing-certificates API (available since minSdk 28) and compares the
+     * SHA-1 digest against {@code R.string.sign_key}. Fails closed: returns false if the
+     * signature cannot be read or does not match.
+     */
     public boolean checkAppSignature() {
-        final String SIGNATURE = context.getString(R.string.sign_key);
+        final String expected = context.getString(R.string.sign_key);
         try {
             PackageInfo packageInfo = context.getPackageManager()
-                    .getPackageInfo(context.getPackageName(), PackageManager.GET_SIGNATURES);
-            for (Signature signature : packageInfo.signatures) {
+                    .getPackageInfo(context.getPackageName(), PackageManager.GET_SIGNING_CERTIFICATES);
+            SigningInfo signingInfo = packageInfo.signingInfo;
+            if (signingInfo == null) {
+                return false;
+            }
+            Signature[] signatures = signingInfo.hasMultipleSigners()
+                    ? signingInfo.getApkContentsSigners()
+                    : signingInfo.getSigningCertificateHistory();
+            if (signatures == null) {
+                return false;
+            }
+            for (Signature signature : signatures) {
                 MessageDigest md = MessageDigest.getInstance("SHA");
                 md.update(signature.toByteArray());
                 final String currentSignature = Base64.encodeToString(md.digest(), Base64.DEFAULT);
-                if (SIGNATURE.equals(currentSignature)) {
+                if (expected.equals(currentSignature)) {
                     return true;
                 }
             }
         } catch (Exception e) {
-            return true;
+            // fail closed: inability to verify the signature is treated as a tampered app
+            return false;
         }
         return false;
     }
@@ -65,6 +133,10 @@ public class SecurityManager {
 
     public boolean isSimAvailable() {
         TelephonyManager telephonyManager = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
+        // fail closed: a device with no telephony service is treated as not a valid phone
+        if (telephonyManager == null) {
+            return false;
+        }
         return telephonyManager.getSimState() != TelephonyManager.SIM_STATE_ABSENT;
     }
 
@@ -81,30 +153,5 @@ public class SecurityManager {
             }
         }
         return false;
-    }
-
-    public void runSecurityChecks(String testMode, String expectedPackageName, Runnable killCallback) {
-        if (!testMode.equals("on")) {
-            if (!checkAppSignature()) {
-                killCallback.run();
-                return;
-            }
-            if (!context.getPackageName().equals(expectedPackageName)) {
-                killCallback.run();
-                return;
-            }
-            if (!isSimAvailable()) {
-                killCallback.run();
-                return;
-            }
-            if (isEmulator()) {
-                killCallback.run();
-                return;
-            }
-            if (isDeviceRooted()) {
-                killCallback.run();
-                return;
-            }
-        }
     }
 }


### PR DESCRIPTION
## Problem

The app's integrity checks (signature, package name, SIM, emulator, root) were gated by a **runtime string flag** `sec_check_signature` in the gitignored `unofficial_strings.xml` — a compile-time constant that had to be hand-edited and rebuilt to toggle (a recurring source of friction), and which was also **overloaded** as a "is this a debug build?" flag in `RewardManager`.

Worse, enforcement was effectively broken:
- `killActifit()` did an async `finish()` with **no `return`**, so app initialization continued past a failed check (and could fire multiple toasts).
- `checkAppSignature()` **failed open** — returned "valid" on any exception.
- A clean `SecurityManager.runSecurityChecks()` existed but was **dead code**; the real logic was duplicated inline in `MainActivity`.

## Changes

- **Build-type driven switch.** Replace the string flag with `BuildConfig.ENFORCE_SECURITY`: **release = on, debug = off**, overridable via `enforce.security=true|false` in `local.properties`/CI (`resolveEnforceSecurity` validates it to a real boolean, so a malformed value can't inject into generated `BuildConfig`). No more editing a gitignored file to toggle security.
- **Single source of truth.** `SecurityManager.runSecurityChecks()` now returns a `SecurityResult` (pass, or first failure + reason). Removed the duplicated inline block, the dead overload, and the duplicate `MainActivity` helpers (`static isEmulator`, `checkAppSignature`, `isSimAvailable`, `VALID/INVALID`, unused `RootBeer` import). MainActivity is ~65 lines lighter.
- **Fail closed.** Signature check returns invalid on null/exception, modernized to `GET_SIGNING_CERTIFICATES` (valid since minSdk 28), **keeping SHA-1 so the existing `sign_key` still matches**. `isSimAvailable` null-checks `TelephonyManager`.
- **Actually halts.** On failure: mark the run killed, stop the background pass (`return`), and `onPostExecute` bails before any dashboard work; `killActifit` now uses `finishAffinity()` to tear down the whole task.
- **De-overloaded flag.** `RewardManager` reads `BuildConfig.ENFORCE_SECURITY` for the debug-vs-friendly ad-error message.
- **Version bump** to `v0.14.1` (versionCode 65).

All five checks are retained (fixed, not removed). `sec_check_signature` is now unused; `test_mode` is untouched (still drives test/live URL switching).

## Testing

- `compileDebugJavaWithJavac` + `compileReleaseJavaWithJavac` pass (only pre-existing Java 8 target/deprecation warnings).
- Generated `BuildConfig` verified: debug `ENFORCE_SECURITY=false`, release `ENFORCE_SECURITY=true`.
- Independent review pass: no blockers; enforcement now genuinely halts, signature check is fail-closed, removed duplicates have zero dangling references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)