### PR TITLE
Signature check: accept a list of SHA-256 cert fingerprints

### DIFF
--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/SecurityManager.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/SecurityManager.java
@@ -8,11 +8,13 @@ import android.content.pm.Signature;
 import android.content.pm.SigningInfo;
 import android.os.Build;
 import android.telephony.TelephonyManager;
-import android.util.Base64;
 
 import com.scottyab.rootbeer.RootBeer;
 
 import java.security.MessageDigest;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
 
 /**
  * Single source of truth for the app's integrity checks: app-signature validation,
@@ -82,13 +84,29 @@ public class SecurityManager {
     }
 
     /**
-     * Verifies the running APK is signed with the expected certificate.
+     * Verifies the running APK is signed with one of the expected certificates.
+     *
      * Uses the modern signing-certificates API (available since minSdk 28) and compares the
-     * SHA-1 digest against {@code R.string.sign_key}. Fails closed: returns false if the
-     * signature cannot be read or does not match.
+     * SHA-256 digest of each signer against the allow-list in {@code R.string.sign_key} — a
+     * comma-separated list of SHA-256 hex fingerprints (colons and whitespace are ignored, so
+     * values can be pasted straight from Play Console or {@code keytool}). This normally holds
+     * BOTH the Play app-signing key (what end users' installs are signed with) and the upload
+     * key (what locally built/sideloaded test builds are signed with).
+     *
+     * Fails closed: returns false if the allow-list is empty, the signature cannot be read, or
+     * no signer matches.
      */
     public boolean checkAppSignature() {
-        final String expected = context.getString(R.string.sign_key);
+        Set<String> allowed = new HashSet<>();
+        for (String part : context.getString(R.string.sign_key).split("[,\\s]+")) {
+            String fingerprint = normalizeFingerprint(part);
+            if (!fingerprint.isEmpty()) {
+                allowed.add(fingerprint);
+            }
+        }
+        if (allowed.isEmpty()) {
+            return false;
+        }
         try {
             PackageInfo packageInfo = context.getPackageManager()
                     .getPackageInfo(context.getPackageName(), PackageManager.GET_SIGNING_CERTIFICATES);
@@ -103,10 +121,9 @@ public class SecurityManager {
                 return false;
             }
             for (Signature signature : signatures) {
-                MessageDigest md = MessageDigest.getInstance("SHA");
+                MessageDigest md = MessageDigest.getInstance("SHA-256");
                 md.update(signature.toByteArray());
-                final String currentSignature = Base64.encodeToString(md.digest(), Base64.DEFAULT);
-                if (expected.equals(currentSignature)) {
+                if (allowed.contains(normalizeFingerprint(bytesToHex(md.digest())))) {
                     return true;
                 }
             }
@@ -115,6 +132,22 @@ public class SecurityManager {
             return false;
         }
         return false;
+    }
+
+    /** Reduces a fingerprint to bare uppercase hex so "D6:74:.." and "d674.." compare equal. */
+    private static String normalizeFingerprint(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replaceAll("[^0-9A-Fa-f]", "").toUpperCase(Locale.ROOT);
+    }
+
+    private static String bytesToHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            sb.append(String.format("%02X", b));
+        }
+        return sb.toString();
     }
 
     public boolean isEmulator() {


### PR DESCRIPTION
## Problem

`SecurityManager.checkAppSignature()` compared the running app's cert against a **single** Base64 SHA-1 value in `R.string.sign_key`. That value is the **upload-key** fingerprint — but with **Play App Signing**, Google re-signs distributed apps with its own key. So the app your users actually run is signed with the Play key, which never matched `sign_key`.

Result: with enforcement on, **every Play install would fail the signature check and the app would kill itself.** It only ever "passed" for locally sideloaded (upload-key-signed) builds, and only while enforcement was off — which is why the check has never actually protected the shipped app.

Verified empirically by pulling the installed app off a device:
- App users run (Play app-signing key): `SHA-256 D6:74:D3:0C…`
- Upload key (`actifit_fit_track.jks`): `SHA-256 7F:CD:75:8B…`

## Change

`checkAppSignature()` now validates against an **allow-list**:
- `sign_key` is a **comma-separated list of SHA-256 hex fingerprints**; colons and whitespace are ignored, so values paste straight from Play Console / `keytool`. Populate it with **both** the Play app-signing key (real users) and the upload key (local/sideloaded test builds).
- Digest switched **SHA-1 → SHA-256**, compared as normalized hex.
- Still **fails closed** (empty allow-list, unreadable signature, or no signer match ⇒ tampered) and still loops over all signers via `GET_SIGNING_CERTIFICATES` (minSdk 28).

## ⚠️ Required config change (not in this PR)

`sign_key` lives in the gitignored `unofficial_strings.xml`, so it isn't in this diff. It **must** be updated to the new format for the check to pass under enforcement:

```xml
<string name="sign_key" translatable="false">D6:74:D3:0C:3A:6E:C2:E9:ED:D2:FD:F6:5A:DA:61:A8:F2:29:01:00:03:DB:E2:40:E9:16:3A:8C:88:EC:DA:9E, 7F:CD:75:8B:59:53:34:AD:C7:EF:74:13:20:6E:6D:41:0D:A0:F8:5E:2D:3B:18:36:AF:D3:41:6C:E1:73:AB:20</string>
```

(First = Play app-signing key, second = upload key. Confirm the Play value in Play Console → App integrity → App signing → *App signing key certificate* SHA-256.)

Until the config is updated, leave `BuildConfig.ENFORCE_SECURITY` off for release, or the app will treat itself as tampered.

## Testing

- `compileReleaseJavaWithJavac` + `compileDebugJavaWithJavac` pass (only pre-existing Java 8 target/deprecation warnings).
- Enforcement halt path itself was previously verified on-device (a failed check tears down the activity via `finishAffinity`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)