### PR TITLE
Add field diagnostics for HC access + reward-claim errors

### DIFF
--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/TrackingManager.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/TrackingManager.java
@@ -135,6 +135,26 @@ public class TrackingManager {
         }
     }
 
+    /**
+     * Formats a (possibly wrapped) throwable as "SimpleClassName: message" for both logcat and the
+     * user-visible toast, so a field report / screenshot carries the real cause. Unwraps the common
+     * coroutine/future RuntimeException / Completion / Execution wrappers to reach the root cause.
+     */
+    private static String hcErrorDetail(Throwable t) {
+        if (t == null) {
+            return "unknown";
+        }
+        Throwable cause = t;
+        while (cause.getCause() != null && cause.getCause() != cause
+                && (cause instanceof RuntimeException
+                    || cause instanceof java.util.concurrent.CompletionException
+                    || cause instanceof java.util.concurrent.ExecutionException)) {
+            cause = cause.getCause();
+        }
+        String msg = cause.getMessage();
+        return cause.getClass().getSimpleName() + (msg != null ? ": " + msg : "");
+    }
+
     public void checkHealthConnectStatusAndPermissions() {
         if (healthConnectCheckRunning.getAndSet(true)) {
             Log.d(TAG, "Health Connect check is already running.");
@@ -147,9 +167,10 @@ public class TrackingManager {
         if (sdkStatus == HealthConnectClient.SDK_AVAILABLE) {
             healthConnectManager.hasAllPermissions().whenComplete((hasPermissions, throwable) -> {
                 if (throwable != null) {
-                    Log.e(TAG, "Error checking HC permissions: " + throwable.getMessage(), throwable);
+                    String detail = hcErrorDetail(throwable);
+                    Log.e(TAG, "Error checking HC permissions - " + detail, throwable);
                     ((Activity) context).runOnUiThread(() -> Toast.makeText(context,
-                            "Error accessing Health Connect. Falling back.", Toast.LENGTH_LONG).show());
+                            "Error accessing Health Connect [" + detail + "]. Falling back.", Toast.LENGTH_LONG).show());
                     useDefaultTrackingMethod();
                     healthConnectCheckRunning.set(false);
                     return;
@@ -248,8 +269,9 @@ public class TrackingManager {
         healthConnectManager.readAndPersistStepsData(today, mStepsDBHelper).whenComplete((steps, readThrowable) -> {
             ((Activity) context).runOnUiThread(() -> {
                 if (readThrowable != null) {
-                    Log.e(TAG, "Error reading steps from HC: " + readThrowable.getMessage(), readThrowable);
-                    Toast.makeText(context, "Failed to read data from Health Connect. Falling back.", Toast.LENGTH_LONG).show();
+                    String detail = hcErrorDetail(readThrowable);
+                    Log.e(TAG, "Error reading steps from HC - " + detail, readThrowable);
+                    Toast.makeText(context, "Failed to read data from Health Connect [" + detail + "]. Falling back.", Toast.LENGTH_LONG).show();
                     useDefaultTrackingMethod();
                     return;
                 }

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/WalletActivity.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/WalletActivity.java
@@ -426,8 +426,9 @@ public class WalletActivity extends BaseActivity {
                                                 false);
                                     }
                                 } catch (JSONException e) {
-                                    e.printStackTrace();
-                                    displayNotification(error_notification, null, callerContext, callerActivity, false);
+                                    // server responded but not in the expected shape — log the raw body
+                                    Log.e(MainActivity.TAG, "error claiming rewards - unexpected response body: " + response, e);
+                                    displayNotification(error_notification + " (unexpected response)", null, callerContext, callerActivity, false);
                                 }
 
                                 if (progress != null && progress.isShowing()) {
@@ -439,10 +440,26 @@ public class WalletActivity extends BaseActivity {
 
                             @Override
                             public void onErrorResponse(VolleyError error) {
-                                // hide dialog
-                                // error.printStackTrace();
-                                Log.e(MainActivity.TAG, "error claiming rewards");
-                                displayNotification(error_notification, null, callerContext, callerActivity, false);
+                                // diagnostics: capture HTTP status + server body + auth-token presence so
+                                // field-reported failures are actionable (401 = auth, 5xx = server, etc.)
+                                int httpStatus = (error.networkResponse != null) ? error.networkResponse.statusCode : -1;
+                                String body = "";
+                                if (error.networkResponse != null && error.networkResponse.data != null) {
+                                    try {
+                                        body = new String(error.networkResponse.data, java.nio.charset.StandardCharsets.UTF_8);
+                                    } catch (Exception ignored) {
+                                    }
+                                }
+                                boolean tokenPresent = (accessToken != null && !accessToken.isEmpty());
+                                Log.e(MainActivity.TAG, "error claiming rewards - httpStatus=" + httpStatus
+                                        + " tokenPresent=" + tokenPresent + " body=" + body, error);
+                                // surface a concise, screenshot-able detail to the user for field reports
+                                String detail = (httpStatus != -1) ? " (code " + httpStatus + ")"
+                                        : (!tokenPresent ? " (not authenticated)" : " (no server response)");
+                                displayNotification(error_notification + detail, null, callerContext, callerActivity, false);
+                                if (progress != null && progress.isShowing()) {
+                                    progress.dismiss();
+                                }
                                 claimRewards.clearAnimation();
                             }
                         }) {


### PR DESCRIPTION
## Why

Two user-reported errors are surfaced **generically**, so field reports aren't actionable:
- **"Error accessing Health Connect. Falling back."** — the app falls back to sensors (shows 0 steps).
- **"There was an error claiming your rewards."** — and this path even **discarded the real error** (`error.printStackTrace()` was commented out), so we never saw the HTTP status.

@macclean is remote, so this makes both errors carry the real cause **in logcat AND on-screen** — a screenshot alone should be enough to diagnose.

## Changes

**Health Connect** (`TrackingManager`)
- New `hcErrorDetail()` unwraps the coroutine/future `RuntimeException` / `CompletionException` / `ExecutionException` wrappers to the root cause → `"ClassName: message"`.
- Both failure paths (permission check + step read) now log and display it: `Error accessing Health Connect [<detail>]. Falling back.`

**Reward claim** (`WalletActivity`)
- Volley error handler now logs **HTTP status + auth-token presence + response body**, and appends a concise code to the user message: `(code 401)` / `(not authenticated)` / `(no server response)`.
- Parse-failure branch logs the raw body and shows `(unexpected response)`.
- Also **dismisses the "Claiming rewards…" progress dialog on error** (it was leaked on the failure path before).

No behavioral change beyond messaging/logging. The likely follow-up fixes (null-token guard on claim; refactor `HealthConnectManager.hasAllPermissions()` off its fragile hand-rolled continuation bridge) are intentionally deferred until this pins down the actual root cause.

## What we expect to learn
- **Claim:** whether it's `401` (expired/absent token — the token is fetched via an async login gated on a stored posting key), a `5xx` (server), or a parse issue.
- **HC:** the exact exception class/message from `getGrantedPermissions()`.

## Testing
- `compileDebugJavaWithJavac` passes (only pre-existing Java 8 target/deprecation warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)