### PR TITLE
Improve HC dashboard readability + distance/calories; badge fix; 0-kcal fix

### DIFF
--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/ApiManager.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/ApiManager.java
@@ -570,7 +570,7 @@ public class ApiManager {
         JsonArrayRequest transactionRequest = new JsonArrayRequest(Request.Method.GET, notificationsUrl, null, notificationsListArray -> {
             if (notificationsListArray != null && notificationsListArray.length() > 0) {
                 String count = notificationsListArray.length() < 1000 ? notificationsListArray.length() + "" : "999+";
-                notifCount.setText(Html.fromHtml("<sup><small>" + count + "</small></sup>"));
+                notifCount.setText(count); // plain centered text (badge background handles the shape)
                 notifCount.setVisibility(View.VISIBLE);
             }
         }, error -> {});

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/AuraView.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/AuraView.java
@@ -136,6 +136,9 @@ public class AuraView extends View {
     private final Paint arcPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
     private final Paint glowPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
     private final Paint emojiPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    // opaque disc painted in the card colour behind the centre content of the multi-ring dashboard,
+    // so the step count / labels sit on a clean, high-contrast surface instead of over the arcs+glow
+    private final Paint centerFillPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
     private final RectF arcBounds = new RectF();
 
     // secondary activity-ring colours (outer ring uses the animal's signature colour)
@@ -235,6 +238,25 @@ public class AuraView extends View {
         return Color.HSVToColor(hsv);
     }
 
+    private boolean nightMode() {
+        return (getResources().getConfiguration().uiMode
+                & android.content.res.Configuration.UI_MODE_NIGHT_MASK)
+                == android.content.res.Configuration.UI_MODE_NIGHT_YES;
+    }
+
+    /**
+     * In dark mode, lifts a ring colour to a minimum brightness so dark companion colours
+     * (e.g. Penguin slate) don't vanish against the dark card. No-op in light mode / for
+     * already-bright colours.
+     */
+    private int visibleRingColor(int color) {
+        if (!nightMode()) return color;
+        float[] hsv = new float[3];
+        Color.colorToHSV(color, hsv);
+        if (hsv[2] < 0.72f) hsv[2] = 0.72f;
+        return Color.HSVToColor(hsv);
+    }
+
     @Override
     protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
@@ -281,6 +303,16 @@ public class AuraView extends View {
             }
             drawRing(canvas, cx, cy, outer, stroke, color, fillFraction, true, glowRadius, intensity, breath);
 
+            // clean opaque centre in the card colour: fills the clear zone inside the innermost ring
+            // (and masks any inward glow bleed) so overlaid counter text reads crisply
+            float discRadius = inner - stroke * 0.5f;
+            if (discRadius > 0) {
+                centerFillPaint.setStyle(Paint.Style.FILL);
+                centerFillPaint.setColor(getContext().getColor(
+                        io.actifit.fitnesstracker.actifitfitnesstracker.R.color.md_theme_cardBackground));
+                canvas.drawCircle(cx, cy, discRadius, centerFillPaint);
+            }
+
             if (showAnimal) {
                 drawAnimal(canvas, cx, cy, outer, R);
             }
@@ -308,14 +340,19 @@ public class AuraView extends View {
                           float fraction, boolean glow, float glowRadius, float intensity, float breath) {
         arcBounds.set(cx - radius, cy - radius, cx + radius, cy + radius);
 
-        trackPaint.setColor(color);
-        trackPaint.setAlpha(clampAlpha((int) (55 * intensity)));
+        boolean night = nightMode();
+        int arcColor = night ? visibleRingColor(color) : color;
+
+        // track groove: coloured in light mode (looks good); a neutral light groove in dark mode so
+        // every ring stays visible regardless of how dark its colour is
+        trackPaint.setColor(night ? 0xFFFFFFFF : color);
+        trackPaint.setAlpha(clampAlpha((int) ((night ? 46 : 55) * intensity)));
         trackPaint.setStrokeWidth(stroke);
         canvas.drawCircle(cx, cy, radius, trackPaint);
 
         float sweep = 360f * fraction;
         if (glow) {
-            glowPaint.setColor(color);
+            glowPaint.setColor(arcColor);
             glowPaint.setStrokeWidth(stroke);
             glowPaint.setAlpha(clampAlpha((int) ((70 + 120 * breath + level * 6) * intensity)));
             glowPaint.setMaskFilter(new BlurMaskFilter(Math.max(1f, glowRadius), BlurMaskFilter.Blur.NORMAL));
@@ -326,7 +363,7 @@ public class AuraView extends View {
             }
         }
         if (sweep > 0) {
-            arcPaint.setColor(color);
+            arcPaint.setColor(arcColor);
             arcPaint.setAlpha(clampAlpha((int) (255 * intensity)));
             arcPaint.setStrokeWidth(stroke);
             arcPaint.setMaskFilter(null);

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/AuraView.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/AuraView.java
@@ -136,9 +136,14 @@ public class AuraView extends View {
     private final Paint arcPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
     private final Paint glowPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
     private final Paint emojiPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
-    // opaque disc painted in the card colour behind the centre content of the multi-ring dashboard,
-    // so the step count / labels sit on a clean, high-contrast surface instead of over the arcs+glow
+    // opaque disc painted behind the centre content of the multi-ring dashboard, so the step count /
+    // labels sit on a clean, high-contrast surface instead of over the arcs+glow
     private final Paint centerFillPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    // centre-disc colour; opt-in via setCenterFillColor(). TRANSPARENT (default) = no disc, so the
+    // Profile screen's rings (on a different surface) are unaffected.
+    private int centerFillColor = Color.TRANSPARENT;
+    // reused across draws to avoid per-frame allocation
+    private final float[] hsvScratch = new float[3];
     private final RectF arcBounds = new RectF();
 
     // secondary activity-ring colours (outer ring uses the animal's signature colour)
@@ -238,10 +243,17 @@ public class AuraView extends View {
         return Color.HSVToColor(hsv);
     }
 
-    private boolean nightMode() {
-        return (getResources().getConfiguration().uiMode
-                & android.content.res.Configuration.UI_MODE_NIGHT_MASK)
-                == android.content.res.Configuration.UI_MODE_NIGHT_YES;
+    /**
+     * Sets the colour of the opaque centre disc drawn inside the innermost ring (multi-ring mode)
+     * so overlaid centre text reads crisply against the surface it sits on. Default
+     * {@link Color#TRANSPARENT} = no disc; only the dashboard opts in, so Profile's rings (a
+     * different surface) stay clean.
+     */
+    public void setCenterFillColor(int color) {
+        if (centerFillColor != color) {
+            centerFillColor = color;
+            invalidate();
+        }
     }
 
     /**
@@ -249,12 +261,11 @@ public class AuraView extends View {
      * (e.g. Penguin slate) don't vanish against the dark card. No-op in light mode / for
      * already-bright colours.
      */
-    private int visibleRingColor(int color) {
-        if (!nightMode()) return color;
-        float[] hsv = new float[3];
-        Color.colorToHSV(color, hsv);
-        if (hsv[2] < 0.72f) hsv[2] = 0.72f;
-        return Color.HSVToColor(hsv);
+    private int visibleRingColor(int color, boolean night) {
+        if (!night) return color;
+        Color.colorToHSV(color, hsvScratch);
+        if (hsvScratch[2] < 0.72f) hsvScratch[2] = 0.72f;
+        return Color.HSVToColor(hsvScratch);
     }
 
     @Override
@@ -277,6 +288,7 @@ public class AuraView extends View {
         }
 
         int color = auraColor();
+        boolean night = Utils.isDarkModeActive(getContext());
 
         // size everything relative to the view radius so the same aura works at any size
         float R = Math.min(getWidth(), getHeight()) / 2f;
@@ -296,20 +308,19 @@ public class AuraView extends View {
             float glowRadius = Math.min(glowMax, R * (0.06f + 0.03f * level) * (0.6f + 0.8f * breath));
 
             if (inner > 0) {
-                drawRing(canvas, cx, cy, inner, stroke, COLOR_CALORIES, calFraction, false, 0, intensity, breath);
+                drawRing(canvas, cx, cy, inner, stroke, COLOR_CALORIES, calFraction, false, 0, intensity, breath, night);
             }
             if (middle > 0) {
-                drawRing(canvas, cx, cy, middle, stroke, COLOR_DISTANCE, distFraction, false, 0, intensity, breath);
+                drawRing(canvas, cx, cy, middle, stroke, COLOR_DISTANCE, distFraction, false, 0, intensity, breath, night);
             }
-            drawRing(canvas, cx, cy, outer, stroke, color, fillFraction, true, glowRadius, intensity, breath);
+            drawRing(canvas, cx, cy, outer, stroke, color, fillFraction, true, glowRadius, intensity, breath, night);
 
-            // clean opaque centre in the card colour: fills the clear zone inside the innermost ring
-            // (and masks any inward glow bleed) so overlaid counter text reads crisply
+            // opt-in opaque centre: only drawn when a surface colour has been set (dashboard), filling
+            // the clear zone inside the innermost ring so overlaid counter text reads crisply
             float discRadius = inner - stroke * 0.5f;
-            if (discRadius > 0) {
+            if (discRadius > 0 && Color.alpha(centerFillColor) != 0) {
                 centerFillPaint.setStyle(Paint.Style.FILL);
-                centerFillPaint.setColor(getContext().getColor(
-                        io.actifit.fitnesstracker.actifitfitnesstracker.R.color.md_theme_cardBackground));
+                centerFillPaint.setColor(centerFillColor);
                 canvas.drawCircle(cx, cy, discRadius, centerFillPaint);
             }
 
@@ -323,7 +334,7 @@ public class AuraView extends View {
             float radius = (R - glowMax - stroke * 0.5f) * (1f + 0.03f * breath);
             if (radius <= 0) return;
             float glowRadius = Math.min(glowMax, R * (0.09f + 0.035f * level) * (0.6f + 0.8f * breath));
-            drawRing(canvas, cx, cy, radius, stroke, color, fillFraction, true, glowRadius, intensity, breath);
+            drawRing(canvas, cx, cy, radius, stroke, color, fillFraction, true, glowRadius, intensity, breath, night);
 
             if (showAnimal) {
                 drawAnimal(canvas, cx, cy, radius, R);
@@ -337,11 +348,11 @@ public class AuraView extends View {
 
     // draws one ring: faint full track + optional blurred glow + the progress arc
     private void drawRing(Canvas canvas, float cx, float cy, float radius, float stroke, int color,
-                          float fraction, boolean glow, float glowRadius, float intensity, float breath) {
+                          float fraction, boolean glow, float glowRadius, float intensity, float breath,
+                          boolean night) {
         arcBounds.set(cx - radius, cy - radius, cx + radius, cy + radius);
 
-        boolean night = nightMode();
-        int arcColor = night ? visibleRingColor(color) : color;
+        int arcColor = visibleRingColor(color, night);
 
         // track groove: coloured in light mode (looks good); a neutral light groove in dark mode so
         // every ring stays visible regardless of how dark its colour is

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/ChartManager.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/ChartManager.java
@@ -203,10 +203,11 @@ public class ChartManager {
             stepRingHc = ((android.app.Activity) context).findViewById(R.id.step_ring_hc);
             android.widget.TextView tvCount = ((android.app.Activity) context).findViewById(R.id.tv_step_count_hc);
             android.widget.TextView tvGoal = ((android.app.Activity) context).findViewById(R.id.tv_step_goal_hc);
-            android.widget.TextView tvPct = ((android.app.Activity) context).findViewById(R.id.tv_step_pct_hc);
             if (stepRingHc == null) return;
 
-            updateRing(stepRingHc, tvCount, tvGoal, tvPct, stepCount, animate);
+            // tv_step_pct_hc is owned by MainActivity.updateHcDashboardRings (the distance/calorie
+            // metrics line) in the multi-ring HC view, so don't overwrite it with "% to goal" here
+            updateRing(stepRingHc, tvCount, tvGoal, null, stepCount, animate);
 
             if (stepCount > 2000) {
                 if (BtnWaves != null && (BtnWaves.getAnimation() == null || !BtnWaves.getAnimation().hasStarted())) {

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/HealthConnectManager.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/HealthConnectManager.java
@@ -199,13 +199,16 @@ public class HealthConnectManager {
                 double steps = (total != null) ? total : 0;
                 double distanceMeters = -1;
                 double kcal = -1;
+                // null aggregate == permission granted but no data source for that metric today;
+                // return -1 (not 0) so callers fall back to a step-derived estimate instead of
+                // showing a misleading "0 km" / "0 kcal"
                 if (hasDistance) {
                     Length len = result.get(DistanceRecord.DISTANCE_TOTAL);
-                    distanceMeters = (len != null) ? len.getMeters() : 0;
+                    distanceMeters = (len != null) ? len.getMeters() : -1;
                 }
                 if (hasCalories) {
                     Energy en = result.get(ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL);
-                    kcal = (en != null) ? en.getKilocalories() : 0;
+                    kcal = (en != null) ? en.getKilocalories() : -1;
                 }
                 return new double[]{steps, distanceMeters, kcal};
             });

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
@@ -2835,6 +2835,9 @@ public class MainActivity extends BaseActivity {
 
         rings.setShowAnimal(false); // the animated animal already sits in the counter centre
         rings.setCompanion(companion);
+        // opt this AuraView into the centre disc (card colour) so the counter reads cleanly; other
+        // AuraViews (e.g. Profile, on a different surface) never opt in and stay disc-free
+        rings.setCenterFillColor(getColor(R.color.md_theme_cardBackground));
         rings.setActivityRings(steps / 10000f, distKm / 8f, calVal / 500f, level, wilting);
         rings.setVisibility(View.VISIBLE);
         if (materialRing != null) materialRing.setVisibility(View.GONE);
@@ -2848,7 +2851,7 @@ public class MainActivity extends BaseActivity {
             boolean calEstimated = (kcal < 0);
             float distForLegend = distEstimated ? distKm * 1000f : distanceMeters;
             String distStr = (distEstimated ? "≈" : "") + Utils.formatDistance(this, distForLegend);
-            String calStr = (calEstimated ? "≈" : "") + Math.round(calVal) + " kcal";
+            String calStr = (calEstimated ? "≈" : "") + Math.round(calVal) + " " + getString(R.string.kcal_unit);
             hcMetrics.setText("📏 " + distStr + "    🔥 " + calStr);
         }
     }

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
@@ -2838,6 +2838,15 @@ public class MainActivity extends BaseActivity {
         rings.setActivityRings(steps / 10000f, distKm / 8f, calVal / 500f, level, wilting);
         rings.setVisibility(View.VISIBLE);
         if (materialRing != null) materialRing.setVisibility(View.GONE);
+
+        // surface the extra HC metrics (distance + calories) under the step count, matching the
+        // profile legend; distance honors the user's measurement system (km / mi)
+        TextView hcMetrics = findViewById(R.id.tv_step_pct_hc);
+        if (hcMetrics != null) {
+            float distForLegend = (distanceMeters >= 0) ? distanceMeters : distKm * 1000f;
+            hcMetrics.setText("📏 " + Utils.formatDistance(this, distForLegend)
+                    + "    🔥 " + Math.round(calVal) + " kcal");
+        }
     }
 
     /** Renders the companion aura (header ring) and the spirit animal inside the step counter. */

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
@@ -2840,12 +2840,16 @@ public class MainActivity extends BaseActivity {
         if (materialRing != null) materialRing.setVisibility(View.GONE);
 
         // surface the extra HC metrics (distance + calories) under the step count, matching the
-        // profile legend; distance honors the user's measurement system (km / mi)
+        // profile legend; distance honors the user's measurement system (km / mi). Values with no
+        // real HC data source are step-derived estimates and get a "≈" prefix.
         TextView hcMetrics = findViewById(R.id.tv_step_pct_hc);
         if (hcMetrics != null) {
-            float distForLegend = (distanceMeters >= 0) ? distanceMeters : distKm * 1000f;
-            hcMetrics.setText("📏 " + Utils.formatDistance(this, distForLegend)
-                    + "    🔥 " + Math.round(calVal) + " kcal");
+            boolean distEstimated = (distanceMeters < 0);
+            boolean calEstimated = (kcal < 0);
+            float distForLegend = distEstimated ? distKm * 1000f : distanceMeters;
+            String distStr = (distEstimated ? "≈" : "") + Utils.formatDistance(this, distForLegend);
+            String calStr = (calEstimated ? "≈" : "") + Math.round(calVal) + " kcal";
+            hcMetrics.setText("📏 " + distStr + "    🔥 " + calStr);
         }
     }
 

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
@@ -4261,7 +4261,8 @@ public class MainActivity extends BaseActivity {
             if (notificationsListArray != null && notificationsListArray.length() > 0) {
                 String count = notificationsListArray.length() < 1000 ? notificationsListArray.length() + ""
                         : "999+";
-                notifCount.setText(Html.fromHtml("<sup><small>" + count + "</small></sup>"));
+                // plain centered text (no <sup>, which pushed the number to the top of the badge)
+                notifCount.setText(count);
                 notifCount.setVisibility(View.VISIBLE);
             }
         }, error -> {

--- a/app/src/main/res/drawable/circle_badge.xml
+++ b/app/src/main/res/drawable/circle_badge.xml
@@ -1,7 +1,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="oval">
 
-    <solid android:color="#0a660a" /> <!-- darker green -->
+    <solid android:color="@color/badge_green" />
 
     <size
         android:width="14dp"

--- a/app/src/main/res/drawable/notif_badge_pill.xml
+++ b/app/src/main/res/drawable/notif_badge_pill.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Notification count badge: a rounded "stadium" so it stays a circle for 1-2 digits and
+     grows into a pill for larger counts instead of clipping the number. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <solid android:color="#0a660a" /> <!-- darker green, matches circle_badge -->
+
+    <corners android:radius="10dp" />
+</shape>

--- a/app/src/main/res/drawable/notif_badge_pill.xml
+++ b/app/src/main/res/drawable/notif_badge_pill.xml
@@ -4,7 +4,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
 
-    <solid android:color="#0a660a" /> <!-- darker green, matches circle_badge -->
+    <solid android:color="@color/badge_green" />
 
     <corners android:radius="10dp" />
 </shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -518,8 +518,8 @@
 
                                     <com.airbnb.lottie.LottieAnimationView
                                         android:id="@+id/companion_animal_hc"
-                                        android:layout_width="44dp"
-                                        android:layout_height="44dp"
+                                        android:layout_width="34dp"
+                                        android:layout_height="34dp"
                                         app:lottie_autoPlay="true"
                                         app:lottie_loop="true" />
 
@@ -527,8 +527,8 @@
                                         android:id="@+id/tv_step_count_hc"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:textColor="@color/actifitRed"
-                                        android:textSize="32sp"
+                                        android:textColor="@color/md_theme_onSurface"
+                                        android:textSize="26sp"
                                         android:textStyle="bold"
                                         android:text="0" />
 
@@ -536,15 +536,18 @@
                                         android:id="@+id/tv_step_goal_hc"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:textSize="12sp"
+                                        android:textColor="@color/md_theme_textSecondary"
+                                        android:textSize="11sp"
                                         android:text="/ 10,000 steps" />
 
+                                    <!-- HC extras (distance + calories); populated in updateHcDashboardRings -->
                                     <TextView
                                         android:id="@+id/tv_step_pct_hc"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
+                                        android:textColor="@color/md_theme_textSecondary"
                                         android:textSize="10sp"
-                                        android:text="0% to goal" />
+                                        android:text="" />
                                 </LinearLayout>
                             </FrameLayout>
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -141,11 +141,15 @@
 
                 <TextView
                     android:id="@+id/notif_count"
-                    android:layout_width="@dimen/badge_size"
-                    android:layout_height="@dimen/badge_size"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:minWidth="@dimen/badge_size"
+                    android:minHeight="@dimen/badge_size"
                     android:layout_gravity="top|end"
-                    android:background="@drawable/circle_badge"
+                    android:background="@drawable/notif_badge_pill"
                     android:gravity="center"
+                    android:paddingHorizontal="4dp"
+                    android:paddingVertical="1dp"
                     android:textColor="@color/colorWhite"
                     android:textSize="@dimen/badge_text_size"
                     android:visibility="gone" />

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -527,11 +527,12 @@
                                         app:lottie_autoPlay="true"
                                         app:lottie_loop="true" />
 
+                                    <!-- colour is set at runtime by ChartManager.updateRing (milestone red/green) -->
                                     <TextView
                                         android:id="@+id/tv_step_count_hc"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:textColor="@color/md_theme_onSurface"
+                                        android:textColor="@color/actifitRed"
                                         android:textSize="26sp"
                                         android:textStyle="bold"
                                         android:text="0" />
@@ -544,13 +545,16 @@
                                         android:textSize="11sp"
                                         android:text="/ 10,000 steps" />
 
-                                    <!-- HC extras (distance + calories); populated in updateHcDashboardRings -->
+                                    <!-- HC extras (distance + calories); populated in updateHcDashboardRings.
+                                         textDirection=ltr keeps the emoji/number order stable in RTL locales -->
                                     <TextView
                                         android:id="@+id/tv_step_pct_hc"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
                                         android:textColor="@color/md_theme_textSecondary"
                                         android:textSize="10sp"
+                                        android:textStyle="bold"
+                                        android:textDirection="ltr"
                                         android:text="" />
                                 </LinearLayout>
                             </FrameLayout>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -6,7 +6,8 @@
     <color name="colorAccent">#FF5252</color>
     <color name="actifitRed">#FF5252</color>
     <color name="actifitGreen">#32CD32</color>
-    <color name="actifitDarkGreen">#008000</color>
+    <color name="actifitDarkGreen">#4CAF50</color><!-- brighter green: #008000 was ~2.4:1 on the dark card -->
+
     <color name="colorWhite">#121212</color>
     <color name="colorBlack">#FFFFFF</color>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,6 +7,7 @@
     <color name="actifitRed">#FF112D</color>
     <color name="actifitGreen">#00FF00</color>
     <color name="actifitDarkGreen">#006400</color>
+    <color name="badge_green">#0a660a</color><!-- notification count badge (circle_badge + notif_badge_pill) -->
     <color name="colorWhite">#FFFFFF</color>
     <color name="colorBlack">#000000</color>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -506,6 +506,7 @@
     <string name="default_login_img" translatable="false">https://raw.githubusercontent.com/actifit/actifit-landingpage/master/static/img/insta_achive_earn.png</string>
     <string name="ad_not_ready">The rewarded ad wasn\'t ready yet.</string>
     <string name="err_load_ad">error loading ad</string>
+    <string name="kcal_unit">kcal</string>
     <string name="wave_hint_1">Share a quick update...</string>
     <string name="wave_preview">Preview</string>
     <string name="report_text_hint_1">Describe your day\'s activity using original content in as little as a few sentences. The more the merrier!</string>


### PR DESCRIPTION
Polishes the multi-ring Health Connect dashboard after a moderator reported it was hard to read. Verified on-device (light + dark).

## Changes

**Dashboard readability** (`AuraView`, `activity_main.xml`, `MainActivity`)
- Opt-in opaque **center disc** in the card color so the counter sits on a clean surface (not over the arcs/glow). Disc is off by default (`AuraView.setCenterFillColor`, `TRANSPARENT`) — only the dashboard opts in.
- **Dark mode:** ring tracks now use a neutral light groove (the old color-at-21%-alpha vanished on the dark card) and dark ring colors are lifted to a minimum brightness so no ring is lost. Light mode unchanged.
- Step count 32→26sp, animal 44→34dp so content fits the clear center; labels → `md_theme_textSecondary`.

**Distance + calories** (`MainActivity`)
- Extra HC metrics shown under the step count as `📏 distance  🔥 calories` (**bold**), distance honoring the user's measurement system via `Utils.formatDistance`. Estimated values (no real HC source) are prefixed `≈`. `textDirection=ltr` keeps order stable in RTL locales; `kcal` is a string resource.

**Fix "0 kcal"** (`HealthConnectManager`)
- `readTodayMetrics` coerced a missing distance/calorie aggregate to `0` instead of `-1`, so "granted but no data source" showed `0 kcal` instead of the intended step-derived estimate. Now returns `-1` → caller estimates. (This also silently corrects `ProfileActivity`'s calorie/distance estimate, which already handled `-1`.) Caveat: a genuine zero is now indistinguishable from "no source" and shows as an `≈` estimate.

**Notification badge** (`activity_main.xml`, `MainActivity`, `notif_badge_pill`)
- Was a fixed 18dp oval that clipped 3-digit counts. Now a rounded "stadium": circle for 1–2 digits, pill for larger, with the count centered (dropped the `<sup>` that pushed it to the top).

## Review follow-ups (commit 557eb27)
Addresses the code review:
1. Step-count color: XML `onSurface` never rendered (overwritten by `ChartManager`); real issue was dark-green `#008000` ≈2.4:1 on dark → brightened night `actifitDarkGreen` to `#4CAF50`, reverted the dead XML.
2. `tv_step_pct_hc` two-writer conflict → `ChartManager` passes `null` for `tvPct` in HC multi-ring; metrics own it (no longer vanish on refresh).
3. Center disc leaking into `ProfileActivity` → disc is now opt-in.
4. Metrics kept in center, bold; RTL-safe; `kcal` localized.
5. Minors: fixed the same `<sup>` bug in the unused `ApiManager` duplicate; shared `@color/badge_green`; reuse `Utils.isDarkModeActive`; night computed once/onDraw + cached HSV; dropped redundant ternary.

## Testing
- `compileReleaseJavaWithJavac` + `assembleRelease` pass. Installed and verified on-device across light/dark.