### PR TITLE
Unify multi-ring dashboard across all tracking modes + Fitbit distance/calories

### DIFF
--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/ChartManager.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/ChartManager.java
@@ -145,10 +145,10 @@ public class ChartManager {
             stepRing = ((android.app.Activity) context).findViewById(R.id.step_ring);
             android.widget.TextView tvCount = ((android.app.Activity) context).findViewById(R.id.tv_step_count);
             android.widget.TextView tvGoal = ((android.app.Activity) context).findViewById(R.id.tv_step_goal);
-            android.widget.TextView tvPct = ((android.app.Activity) context).findViewById(R.id.tv_step_pct);
             if (stepRing == null) return;
 
-            updateRing(stepRing, tvCount, tvGoal, tvPct, stepCount, animate);
+            // tv_step_pct owned by MainActivity.updateDeviceDashboardRings (distance/calorie metrics)
+            updateRing(stepRing, tvCount, tvGoal, null, stepCount, animate);
 
             if (stepCount > 2000) {
                 if (BtnWaves != null && (BtnWaves.getAnimation() == null || !BtnWaves.getAnimation().hasStarted())) {
@@ -174,10 +174,10 @@ public class ChartManager {
             stepRingFitbit = ((android.app.Activity) context).findViewById(R.id.step_ring_fitbit);
             android.widget.TextView tvCount = ((android.app.Activity) context).findViewById(R.id.tv_step_count_fitbit);
             android.widget.TextView tvGoal = ((android.app.Activity) context).findViewById(R.id.tv_step_goal_fitbit);
-            android.widget.TextView tvPct = ((android.app.Activity) context).findViewById(R.id.tv_step_pct_fitbit);
             if (stepRingFitbit == null) return;
 
-            updateRing(stepRingFitbit, tvCount, tvGoal, tvPct, stepCount, animate);
+            // tv_step_pct_fitbit owned by MainActivity.updateFitbitDashboardRings (distance/calorie metrics)
+            updateRing(stepRingFitbit, tvCount, tvGoal, null, stepCount, animate);
 
             if (stepCount > 2000) {
                 if (BtnWaves != null && (BtnWaves.getAnimation() == null || !BtnWaves.getAnimation().hasStarted())) {

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/ChartManager.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/ChartManager.java
@@ -149,6 +149,9 @@ public class ChartManager {
 
             // tv_step_pct owned by MainActivity.updateDeviceDashboardRings (distance/calorie metrics)
             updateRing(stepRing, tvCount, tvGoal, null, stepCount, animate);
+            // render the multi-ring dashboard + metrics here (not in MainActivity's wrapper) so every
+            // caller is covered — including TrackingManager.useDefaultTrackingMethod's direct calls
+            if (context instanceof MainActivity) ((MainActivity) context).updateDeviceDashboardRings(stepCount);
 
             if (stepCount > 2000) {
                 if (BtnWaves != null && (BtnWaves.getAnimation() == null || !BtnWaves.getAnimation().hasStarted())) {
@@ -178,6 +181,8 @@ public class ChartManager {
 
             // tv_step_pct_fitbit owned by MainActivity.updateFitbitDashboardRings (distance/calorie metrics)
             updateRing(stepRingFitbit, tvCount, tvGoal, null, stepCount, animate);
+            // render rings + metrics here so TrackingManager's direct calls are covered too
+            if (context instanceof MainActivity) ((MainActivity) context).updateFitbitDashboardRings(stepCount);
 
             if (stepCount > 2000) {
                 if (BtnWaves != null && (BtnWaves.getAnimation() == null || !BtnWaves.getAnimation().hasStarted())) {

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
@@ -1140,33 +1140,38 @@ public class MainActivity extends BaseActivity {
                                 trackedActivityCount += parseInt(stepActivityArray.getJSONObject(i).getString("value"));
                             }
 
-                            displayActivityChartFitbit(trackedActivityCount, true);
-                            Calendar mCalendar = Calendar.getInstance();
+                            // also fetch Fitbit's own distance + activity calories for the multi-metric
+                            // rings. activityCalories (not tracker/calories, which includes BMR) keeps
+                            // parity with Health Connect's active-calories. Distance is returned in the
+                            // account's unit, so convert to metres via the profile's distanceUnit.
+                            float fbDistRaw = sumFitbitActivityResource(fitbit, "tracker/distance", targetDate);
+                            float fbCal = sumFitbitActivityResource(fitbit, "activityCalories", targetDate);
+                            float fbDistM = -1f;
+                            if (fbDistRaw >= 0) {
+                                String distUnit = fitbit.getFieldFromProfile("distanceUnit"); // "METRIC"/"en_US" or a sentinel on failure
+                                String u = (distUnit == null) ? "" : distUnit.toUpperCase(java.util.Locale.ROOT);
+                                if (u.contains("US")) {
+                                    fbDistM = fbDistRaw * 1609.344f;      // imperial account -> miles
+                                } else if (u.contains("METRIC")) {
+                                    fbDistM = fbDistRaw * 1000f;          // metric account -> km
+                                }
+                                // else: unknown/failed profile lookup -> leave -1 so distance degrades
+                                // to a "≈" estimate rather than guessing the wrong unit
+                            }
 
-                            editor.putString("fitbitLastSyncDate",
-                                    new SimpleDateFormat("yyyyMMdd").format(
-                                            mCalendar.getTime()));
+                            Calendar mCalendar = Calendar.getInstance();
+                            String todayStamp = new SimpleDateFormat("yyyyMMdd").format(mCalendar.getTime());
+                            editor.putString("fitbitLastSyncDate", todayStamp);
                             editor.putLong("fitbitLastSyncTime", System.currentTimeMillis());
                             // TODO: demo data, replace when go live
                             editor.putInt("fitbitSyncCount", trackedActivityCount);// 6543);//
-                            editor.apply();
-
-                            // also fetch Fitbit's own distance + calories for the multi-metric rings.
-                            // Distance comes back in the account's unit (km/mi), so convert to metres.
-                            float fbDistRaw = sumFitbitTrackerMetric(fitbit, "distance", targetDate);
-                            float fbCal = sumFitbitTrackerMetric(fitbit, "calories", targetDate);
-                            float fbDistM = -1f;
-                            if (fbDistRaw >= 0) {
-                                String distUnit = fitbit.getFieldFromProfile("distanceUnit");
-                                boolean miles = distUnit != null && distUnit.toUpperCase().contains("US");
-                                fbDistM = fbDistRaw * (miles ? 1609.344f : 1000f);
-                            }
                             editor.putFloat("fitbitDistanceM", fbDistM);
                             editor.putFloat("fitbitCalories", fbCal);
+                            editor.putString("fitbitMetricsDate", todayStamp); // freshness stamp: stale -> estimate
                             editor.apply();
-                            final int fbSteps = trackedActivityCount;
-                            final float fbDistFinal = fbDistM, fbCalFinal = fbCal;
-                            runOnUiThread(() -> updateFitbitDashboardRings(fbSteps, fbDistFinal, fbCalFinal));
+
+                            // render after the metrics are cached, so the rings pick up fresh values
+                            displayActivityChartFitbit(trackedActivityCount, true);
                         } else {
                             Log.d(MainActivity.TAG, "No auto-tracked activity found for today");
                         }
@@ -2546,14 +2551,16 @@ public class MainActivity extends BaseActivity {
     }
 
     /**
-     * Sums a Fitbit daily tracker time-series resource ("distance" / "calories"). Returns the raw
-     * summed value (distance in the account's unit, calories in kcal), or -1 if unavailable so
-     * callers fall back to a step-derived estimate. Runs on a background thread.
+     * Sums a Fitbit daily activity time-series resource by its path under "activities/"
+     * (e.g. "tracker/distance", "activityCalories"). Returns the raw summed value (distance in the
+     * account's unit, calories in kcal), or -1 if unavailable so callers fall back to a step-derived
+     * estimate. Note the deliberate asymmetry: an empty/unavailable dataset returns -1 (→ estimate),
+     * whereas a dataset of genuine zeros sums to 0 (shown as a real "0"). Runs on a background thread.
      */
-    private float sumFitbitTrackerMetric(NxFitbitHelper fitbit, String metric, String targetDate) {
+    private float sumFitbitActivityResource(NxFitbitHelper fitbit, String resourcePath, String targetDate) {
         try {
-            JSONObject list = fitbit.getActivityByDate(metric, targetDate);
-            JSONArray arr = list.getJSONArray("activities-tracker-" + metric);
+            JSONObject list = fitbit.getActivityResource(resourcePath, targetDate);
+            JSONArray arr = list.getJSONArray("activities-" + resourcePath.replace("/", "-"));
             if (arr.length() == 0) return -1f;
             float sum = 0f;
             for (int i = 0; i < arr.length(); i++) {
@@ -2561,19 +2568,14 @@ public class MainActivity extends BaseActivity {
             }
             return sum;
         } catch (Exception e) {
-            Log.e(TAG, "Fitbit " + metric + " fetch failed: " + e.getMessage());
+            Log.e(TAG, "Fitbit " + resourcePath + " fetch failed: " + e.getMessage());
             return -1f;
         }
     }
 
     private void displayActivityChartFitbit(final int stepCount, final boolean animate) {
         currentDisplayedStepCount = stepCount;
-        chartManager.displayActivityChartFitbit(stepCount, animate);
-        // multi-ring + metrics using Fitbit's own distance/calorie readings when synced (else estimate)
-        SharedPreferences fbPrefs = getSharedPreferences("actifitSets", MODE_PRIVATE);
-        float fbDist = fbPrefs.getFloat("fitbitDistanceM", -1f);
-        float fbCal = fbPrefs.getFloat("fitbitCalories", -1f);
-        updateFitbitDashboardRings(stepCount, fbDist, fbCal);
+        chartManager.displayActivityChartFitbit(stepCount, animate); // also renders the Fitbit rings + metrics
         updateNudgeCard(stepCount);
         if (animate) checkMilestoneCelebration(stepCount);
     }
@@ -2587,9 +2589,7 @@ public class MainActivity extends BaseActivity {
 
     private void displayActivityChart(final int stepCount, final boolean animate) {
         currentDisplayedStepCount = stepCount;
-        chartManager.displayActivityChart(stepCount, animate);
-        // sensors mode has no distance/calorie source, so both are step-derived estimates
-        updateDeviceDashboardRings(stepCount);
+        chartManager.displayActivityChart(stepCount, animate); // also renders the sensors rings + metrics
         updateNudgeCard(stepCount);
         if (animate) checkMilestoneCelebration(stepCount);
     }
@@ -2874,10 +2874,19 @@ public class MainActivity extends BaseActivity {
                 steps, -1f, -1f);
     }
 
-    /** Fitbit mode: distance/calories come from the Fitbit sync (real) when available, else -1. */
-    public void updateFitbitDashboardRings(int steps, float distanceMeters, float kcal) {
+    /**
+     * Fitbit mode: distance/calories come from the Fitbit sync (real) when today's values are cached.
+     * A stale cache (not stamped with today's date) falls back to a "≈" estimate rather than showing
+     * yesterday's numbers as today's real data.
+     */
+    public void updateFitbitDashboardRings(int steps) {
+        SharedPreferences prefs = getSharedPreferences("actifitSets", MODE_PRIVATE);
+        String today = new SimpleDateFormat("yyyyMMdd").format(Calendar.getInstance().getTime());
+        boolean fresh = today.equals(prefs.getString("fitbitMetricsDate", ""));
+        float dist = fresh ? prefs.getFloat("fitbitDistanceM", -1f) : -1f;
+        float cal = fresh ? prefs.getFloat("fitbitCalories", -1f) : -1f;
         renderDashboardRings(R.id.dashboard_rings_fitbit, R.id.step_ring_fitbit, R.id.tv_step_pct_fitbit,
-                steps, distanceMeters, kcal);
+                steps, dist, cal);
     }
 
     /**

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
@@ -1140,38 +1140,36 @@ public class MainActivity extends BaseActivity {
                                 trackedActivityCount += parseInt(stepActivityArray.getJSONObject(i).getString("value"));
                             }
 
-                            // also fetch Fitbit's own distance + activity calories for the multi-metric
-                            // rings. activityCalories (not tracker/calories, which includes BMR) keeps
-                            // parity with Health Connect's active-calories. Distance is returned in the
-                            // account's unit, so convert to metres via the profile's distanceUnit.
-                            float fbDistRaw = sumFitbitActivityResource(fitbit, "tracker/distance", targetDate);
-                            float fbCal = sumFitbitActivityResource(fitbit, "activityCalories", targetDate);
-                            float fbDistM = -1f;
-                            if (fbDistRaw >= 0) {
-                                String distUnit = fitbit.getFieldFromProfile("distanceUnit"); // "METRIC"/"en_US" or a sentinel on failure
-                                String u = (distUnit == null) ? "" : distUnit.toUpperCase(java.util.Locale.ROOT);
-                                if (u.contains("US")) {
-                                    fbDistM = fbDistRaw * 1609.344f;      // imperial account -> miles
-                                } else if (u.contains("METRIC")) {
-                                    fbDistM = fbDistRaw * 1000f;          // metric account -> km
-                                }
-                                // else: unknown/failed profile lookup -> leave -1 so distance degrades
-                                // to a "≈" estimate rather than guessing the wrong unit
-                            }
-
-                            Calendar mCalendar = Calendar.getInstance();
-                            String todayStamp = new SimpleDateFormat("yyyyMMdd").format(mCalendar.getTime());
+                            String todayStamp = new SimpleDateFormat("yyyyMMdd", Locale.ENGLISH)
+                                    .format(Calendar.getInstance().getTime());
                             editor.putString("fitbitLastSyncDate", todayStamp);
                             editor.putLong("fitbitLastSyncTime", System.currentTimeMillis());
                             // TODO: demo data, replace when go live
                             editor.putInt("fitbitSyncCount", trackedActivityCount);// 6543);//
-                            editor.putFloat("fitbitDistanceM", fbDistM);
-                            editor.putFloat("fitbitCalories", fbCal);
-                            editor.putString("fitbitMetricsDate", todayStamp); // freshness stamp: stale -> estimate
                             editor.apply();
 
-                            // render after the metrics are cached, so the rings pick up fresh values
+                            // steps render immediately (distance/calories fill in as estimates until the
+                            // fetch below returns); the extra two Fitbit round-trips run off the main
+                            // thread so they don't block the OAuth-return onCreate.
                             displayActivityChartFitbit(trackedActivityCount, true);
+
+                            final int fbSteps = trackedActivityCount;
+                            final String fbTargetDate = targetDate;
+                            new Thread(() -> {
+                                // activityCalories (not tracker/calories, which includes BMR) keeps parity
+                                // with Health Connect's active-calories. Distance always arrives in km
+                                // (Accept-Language: metric, pinned in NxFitbitHelper.makeApiRequest), so the
+                                // km->metres conversion is unconditional; -1 stays -1 -> "≈" estimate.
+                                float fbDistRaw = sumFitbitActivityResource(fitbit, "tracker/distance", fbTargetDate);
+                                float fbCal = sumFitbitActivityResource(fitbit, "activityCalories", fbTargetDate);
+                                float fbDistM = (fbDistRaw >= 0) ? fbDistRaw * 1000f : -1f;
+                                SharedPreferences.Editor ed = getSharedPreferences("actifitSets", MODE_PRIVATE).edit();
+                                ed.putFloat("fitbitDistanceM", fbDistM);
+                                ed.putFloat("fitbitCalories", fbCal);
+                                ed.putString("fitbitMetricsDate", todayStamp); // freshness stamp: stale -> estimate
+                                ed.apply();
+                                runOnUiThread(() -> updateFitbitDashboardRings(fbSteps));
+                            }).start();
                         } else {
                             Log.d(MainActivity.TAG, "No auto-tracked activity found for today");
                         }
@@ -2881,7 +2879,7 @@ public class MainActivity extends BaseActivity {
      */
     public void updateFitbitDashboardRings(int steps) {
         SharedPreferences prefs = getSharedPreferences("actifitSets", MODE_PRIVATE);
-        String today = new SimpleDateFormat("yyyyMMdd").format(Calendar.getInstance().getTime());
+        String today = new SimpleDateFormat("yyyyMMdd", Locale.ENGLISH).format(Calendar.getInstance().getTime());
         boolean fresh = today.equals(prefs.getString("fitbitMetricsDate", ""));
         float dist = fresh ? prefs.getFloat("fitbitDistanceM", -1f) : -1f;
         float cal = fresh ? prefs.getFloat("fitbitCalories", -1f) : -1f;

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/MainActivity.java
@@ -1150,6 +1150,23 @@ public class MainActivity extends BaseActivity {
                             // TODO: demo data, replace when go live
                             editor.putInt("fitbitSyncCount", trackedActivityCount);// 6543);//
                             editor.apply();
+
+                            // also fetch Fitbit's own distance + calories for the multi-metric rings.
+                            // Distance comes back in the account's unit (km/mi), so convert to metres.
+                            float fbDistRaw = sumFitbitTrackerMetric(fitbit, "distance", targetDate);
+                            float fbCal = sumFitbitTrackerMetric(fitbit, "calories", targetDate);
+                            float fbDistM = -1f;
+                            if (fbDistRaw >= 0) {
+                                String distUnit = fitbit.getFieldFromProfile("distanceUnit");
+                                boolean miles = distUnit != null && distUnit.toUpperCase().contains("US");
+                                fbDistM = fbDistRaw * (miles ? 1609.344f : 1000f);
+                            }
+                            editor.putFloat("fitbitDistanceM", fbDistM);
+                            editor.putFloat("fitbitCalories", fbCal);
+                            editor.apply();
+                            final int fbSteps = trackedActivityCount;
+                            final float fbDistFinal = fbDistM, fbCalFinal = fbCal;
+                            runOnUiThread(() -> updateFitbitDashboardRings(fbSteps, fbDistFinal, fbCalFinal));
                         } else {
                             Log.d(MainActivity.TAG, "No auto-tracked activity found for today");
                         }
@@ -2528,9 +2545,35 @@ public class MainActivity extends BaseActivity {
         return df.format(value);
     }
 
+    /**
+     * Sums a Fitbit daily tracker time-series resource ("distance" / "calories"). Returns the raw
+     * summed value (distance in the account's unit, calories in kcal), or -1 if unavailable so
+     * callers fall back to a step-derived estimate. Runs on a background thread.
+     */
+    private float sumFitbitTrackerMetric(NxFitbitHelper fitbit, String metric, String targetDate) {
+        try {
+            JSONObject list = fitbit.getActivityByDate(metric, targetDate);
+            JSONArray arr = list.getJSONArray("activities-tracker-" + metric);
+            if (arr.length() == 0) return -1f;
+            float sum = 0f;
+            for (int i = 0; i < arr.length(); i++) {
+                sum += Float.parseFloat(arr.getJSONObject(i).getString("value"));
+            }
+            return sum;
+        } catch (Exception e) {
+            Log.e(TAG, "Fitbit " + metric + " fetch failed: " + e.getMessage());
+            return -1f;
+        }
+    }
+
     private void displayActivityChartFitbit(final int stepCount, final boolean animate) {
         currentDisplayedStepCount = stepCount;
         chartManager.displayActivityChartFitbit(stepCount, animate);
+        // multi-ring + metrics using Fitbit's own distance/calorie readings when synced (else estimate)
+        SharedPreferences fbPrefs = getSharedPreferences("actifitSets", MODE_PRIVATE);
+        float fbDist = fbPrefs.getFloat("fitbitDistanceM", -1f);
+        float fbCal = fbPrefs.getFloat("fitbitCalories", -1f);
+        updateFitbitDashboardRings(stepCount, fbDist, fbCal);
         updateNudgeCard(stepCount);
         if (animate) checkMilestoneCelebration(stepCount);
     }
@@ -2545,6 +2588,8 @@ public class MainActivity extends BaseActivity {
     private void displayActivityChart(final int stepCount, final boolean animate) {
         currentDisplayedStepCount = stepCount;
         chartManager.displayActivityChart(stepCount, animate);
+        // sensors mode has no distance/calorie source, so both are step-derived estimates
+        updateDeviceDashboardRings(stepCount);
         updateNudgeCard(stepCount);
         if (animate) checkMilestoneCelebration(stepCount);
     }
@@ -2819,8 +2864,31 @@ public class MainActivity extends BaseActivity {
      * Called by TrackingManager once today's HC metrics are read.
      */
     public void updateHcDashboardRings(int steps, float distanceMeters, float kcal) {
-        AuraView rings = findViewById(R.id.dashboard_rings_hc);
-        View materialRing = findViewById(R.id.step_ring_hc);
+        renderDashboardRings(R.id.dashboard_rings_hc, R.id.step_ring_hc, R.id.tv_step_pct_hc,
+                steps, distanceMeters, kcal);
+    }
+
+    /** Sensors/device mode: no real distance/calorie source, so both are step-derived estimates. */
+    public void updateDeviceDashboardRings(int steps) {
+        renderDashboardRings(R.id.dashboard_rings, R.id.step_ring, R.id.tv_step_pct,
+                steps, -1f, -1f);
+    }
+
+    /** Fitbit mode: distance/calories come from the Fitbit sync (real) when available, else -1. */
+    public void updateFitbitDashboardRings(int steps, float distanceMeters, float kcal) {
+        renderDashboardRings(R.id.dashboard_rings_fitbit, R.id.step_ring_fitbit, R.id.tv_step_pct_fitbit,
+                steps, distanceMeters, kcal);
+    }
+
+    /**
+     * Renders the multi-metric activity rings (steps/distance/calories) + the distance/calorie
+     * metrics line for any tracking mode. distanceMeters/kcal &lt; 0 mean "no real source" and are
+     * shown as step-derived estimates with a "≈" prefix.
+     */
+    private void renderDashboardRings(int auraViewId, int materialRingId, int metricsTvId,
+                                      int steps, float distanceMeters, float kcal) {
+        AuraView rings = findViewById(auraViewId);
+        View materialRing = findViewById(materialRingId);
         if (rings == null) return;
 
         SharedPreferences prefs = getSharedPreferences("actifitSets", MODE_PRIVATE);
@@ -2842,17 +2910,17 @@ public class MainActivity extends BaseActivity {
         rings.setVisibility(View.VISIBLE);
         if (materialRing != null) materialRing.setVisibility(View.GONE);
 
-        // surface the extra HC metrics (distance + calories) under the step count, matching the
-        // profile legend; distance honors the user's measurement system (km / mi). Values with no
-        // real HC data source are step-derived estimates and get a "≈" prefix.
-        TextView hcMetrics = findViewById(R.id.tv_step_pct_hc);
-        if (hcMetrics != null) {
+        // surface the extra metrics (distance + calories) under the step count, matching the profile
+        // legend; distance honors the user's measurement system (km / mi). Values with no real data
+        // source are step-derived estimates and get a "≈" prefix.
+        TextView metricsTv = findViewById(metricsTvId);
+        if (metricsTv != null) {
             boolean distEstimated = (distanceMeters < 0);
             boolean calEstimated = (kcal < 0);
             float distForLegend = distEstimated ? distKm * 1000f : distanceMeters;
             String distStr = (distEstimated ? "≈" : "") + Utils.formatDistance(this, distForLegend);
             String calStr = (calEstimated ? "≈" : "") + Math.round(calVal) + " " + getString(R.string.kcal_unit);
-            hcMetrics.setText("📏 " + distStr + "    🔥 " + calStr);
+            metricsTv.setText("📏 " + distStr + "    🔥 " + calStr);
         }
     }
 

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/NxFitbitHelper.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/NxFitbitHelper.java
@@ -180,6 +180,14 @@ class NxFitbitHelper {
 
     }
 
+    // Fetches any daily activity time-series resource by its path under "activities/",
+    // e.g. "tracker/distance" or "activityCalories" (activity-only calories, unlike tracker/calories
+    // which includes BMR). Response key is "activities-" + resourcePath with '/' replaced by '-'.
+    // https://dev.fitbit.com/build/reference/web-api/activity-timeseries/get-activity-timeseries-by-date/
+    JSONObject getActivityResource(String resourcePath, String targetDate) throws InterruptedException, ExecutionException, IOException {
+        return makeApiRequest("user/-/activities/" + resourcePath + "/date/" + targetDate + "/1d.json");
+    }
+
     String getFieldFromProfile(String jsonFieldName) {
         String jsonFieldValue = "An error occurred";
         if (apiValueProfile == null) {

--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/NxFitbitHelper.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/NxFitbitHelper.java
@@ -141,6 +141,12 @@ class NxFitbitHelper {
         OAuth20Service serviceCall = getService();
 
         final OAuthRequest activityrequest = new OAuthRequest(Verb.GET, fitBitAPIUrl + endPointUrl);
+        // Pin the response unit system. Fitbit selects units SOLELY from this header — the account's
+        // own distanceUnit profile field is a display preference and does not affect API responses.
+        // "metric" => distance in km, weight in kg. Value is case-sensitive; a typo silently falls back
+        // to metric, which is why call sites normalise to metres regardless.
+        // https://dev.fitbit.com/build/reference/web-api/developer-guide/application-design/
+        activityrequest.addHeader("Accept-Language", "metric");
         serviceCall.signRequest(accessToken, activityrequest);
 
         final Response response;

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -624,6 +624,14 @@
                                 android:layout_width="match_parent"
                                 android:layout_height="match_parent">
 
+                                <!-- multi-metric activity rings (steps/distance/calories) from Fitbit -->
+                                <io.actifit.fitnesstracker.actifitfitnesstracker.AuraView
+                                    android:id="@+id/dashboard_rings_fitbit"
+                                    android:layout_width="184dp"
+                                    android:layout_height="184dp"
+                                    android:layout_gravity="center"
+                                    android:visibility="gone" />
+
                                 <com.google.android.material.progressindicator.CircularProgressIndicator
                                     android:id="@+id/step_ring_fitbit"
                                     android:layout_width="wrap_content"
@@ -646,17 +654,18 @@
 
                                     <com.airbnb.lottie.LottieAnimationView
                                         android:id="@+id/companion_animal_fitbit"
-                                        android:layout_width="44dp"
-                                        android:layout_height="44dp"
+                                        android:layout_width="34dp"
+                                        android:layout_height="34dp"
                                         app:lottie_autoPlay="true"
                                         app:lottie_loop="true" />
 
+                                    <!-- colour is set at runtime by ChartManager.updateRing (milestone red/green) -->
                                     <TextView
                                         android:id="@+id/tv_step_count_fitbit"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
                                         android:textColor="@color/actifitRed"
-                                        android:textSize="32sp"
+                                        android:textSize="26sp"
                                         android:textStyle="bold"
                                         android:text="0" />
 
@@ -664,15 +673,20 @@
                                         android:id="@+id/tv_step_goal_fitbit"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:textSize="12sp"
+                                        android:textColor="@color/md_theme_textSecondary"
+                                        android:textSize="11sp"
                                         android:text="/ 10,000 steps" />
 
+                                    <!-- distance + calories from Fitbit; populated in updateFitbitDashboardRings -->
                                     <TextView
                                         android:id="@+id/tv_step_pct_fitbit"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
+                                        android:textColor="@color/md_theme_textSecondary"
                                         android:textSize="10sp"
-                                        android:text="0% to goal" />
+                                        android:textStyle="bold"
+                                        android:textDirection="ltr"
+                                        android:text="" />
                                 </LinearLayout>
                             </FrameLayout>
 
@@ -740,6 +754,15 @@
                                 android:layout_width="match_parent"
                                 android:layout_height="match_parent">
 
+                                <!-- multi-metric activity rings (steps/distance/calories); distance &
+                                     calories are step-derived estimates in sensors mode -->
+                                <io.actifit.fitnesstracker.actifitfitnesstracker.AuraView
+                                    android:id="@+id/dashboard_rings"
+                                    android:layout_width="184dp"
+                                    android:layout_height="184dp"
+                                    android:layout_gravity="center"
+                                    android:visibility="gone" />
+
                                 <com.google.android.material.progressindicator.CircularProgressIndicator
                                     android:id="@+id/step_ring"
                                     android:layout_width="wrap_content"
@@ -762,17 +785,18 @@
 
                                     <com.airbnb.lottie.LottieAnimationView
                                         android:id="@+id/companion_animal"
-                                        android:layout_width="44dp"
-                                        android:layout_height="44dp"
+                                        android:layout_width="34dp"
+                                        android:layout_height="34dp"
                                         app:lottie_autoPlay="true"
                                         app:lottie_loop="true" />
 
+                                    <!-- colour is set at runtime by ChartManager.updateRing (milestone red/green) -->
                                     <TextView
                                         android:id="@+id/tv_step_count"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
                                         android:textColor="@color/actifitRed"
-                                        android:textSize="32sp"
+                                        android:textSize="26sp"
                                         android:textStyle="bold"
                                         android:text="0" />
 
@@ -780,15 +804,21 @@
                                         android:id="@+id/tv_step_goal"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:textSize="12sp"
+                                        android:textColor="@color/md_theme_textSecondary"
+                                        android:textSize="11sp"
                                         android:text="/ 10,000 steps" />
 
+                                    <!-- distance + calories; populated in updateDeviceDashboardRings.
+                                         textDirection=ltr keeps emoji/number order stable in RTL locales -->
                                     <TextView
                                         android:id="@+id/tv_step_pct"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
+                                        android:textColor="@color/md_theme_textSecondary"
                                         android:textSize="10sp"
-                                        android:text="0% to goal" />
+                                        android:textStyle="bold"
+                                        android:textDirection="ltr"
+                                        android:text="" />
                                 </LinearLayout>
                             </FrameLayout>
 


### PR DESCRIPTION
Brings the multi-metric ring dashboard (steps/distance/calories + the km·cal legend) to **every** tracking mode. Previously only Health Connect had it; sensors and Fitbit modes still showed the old single ring with no km/cal.

## Changes

**Generalized render** (`MainActivity`)
- `updateHcDashboardRings` → `renderDashboardRings(auraId, materialId, metricsTvId, steps, distanceMeters, kcal)`, with per-mode wrappers: `updateHcDashboardRings`, `updateDeviceDashboardRings` (estimates), `updateFitbitDashboardRings`.
- `distanceMeters/kcal < 0` ⇒ no real source ⇒ step-derived estimate with a `≈` prefix (per-metric).

**Layout** (`activity_main.xml`)
- Added the multi-ring `AuraView` + bold metrics line to the **sensors** and **Fitbit** blocks (same center disc / contrast / sizing as HC). The old `CircularProgressIndicator` is hidden once the rings render.

**Wiring** (`ChartManager`)
- `displayActivityChart` / `displayActivityChartFitbit` now pass `null` for `tvPct`, so the metrics line (owned by MainActivity) isn't overwritten with "% to goal".

**Fitbit real distance + calories** (`MainActivity`)
- The sync now also pulls the tracker's `distance` and `calories` daily time series (`sumFitbitTrackerMetric`), converts distance to meters using the account's `distanceUnit` (km vs miles), caches them (`fitbitDistanceM`, `fitbitCalories`), and feeds the Fitbit rings — **real** values, not estimates.

## Per-mode behavior
| Mode | Distance | Calories |
|---|---|---|
| Health Connect | real (HC) | real if source, else `≈` estimate |
| **Fitbit** | **real (Fitbit)** | **real (Fitbit)** |
| **Sensors** | `≈` estimate | `≈` estimate |

## Testing
- `compileReleaseJavaWithJavac` + `assembleRelease` pass.
- Verified **HC mode** on-device through the new generalized path (real `1.56 km`, `≈113 kcal`).
- ⚠️ **Sensors** and **Fitbit** modes need on-device verification (couldn't switch tracking mode via adb on a release build). Fitbit distance/calorie parsing + the `distanceUnit` conversion should be sanity-checked against a real Fitbit-connected account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)