### PR TITLE
Fix hardcoded step-goal strings (i18n) in ChartManager

### DIFF
--- a/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/ChartManager.java
+++ b/app/src/main/java/io/actifit/fitnesstracker/actifitfitnesstracker/ChartManager.java
@@ -136,8 +136,8 @@ public class ChartManager {
             tvCount.setText(java.text.NumberFormat.getInstance().format(steps));
             tvCount.setTextColor(color);
         }
-        if (tvGoal != null) tvGoal.setText("/ " + java.text.NumberFormat.getInstance().format(DAILY_GOAL) + " steps");
-        if (tvPct != null) tvPct.setText(progress + "% to goal");
+        if (tvGoal != null) tvGoal.setText(context.getString(R.string.step_goal_format, java.text.NumberFormat.getInstance().format(DAILY_GOAL)));
+        if (tvPct != null) tvPct.setText(context.getString(R.string.step_pct_to_goal_format, progress));
     }
 
     public void displayActivityChart(final int stepCount, final boolean animate) {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -767,6 +767,8 @@
     <string name="ai_popup_title">مساعد الذكاء الاصطناعي</string>
     <string name="ai_hint_input">بماذا تريد المساعدة؟</string>
     <string name="ai_accept_button">قبول</string>
+    <string name="step_goal_format">/ %1$s خطوة</string>
+    <string name="step_pct_to_goal_format">%1$d%% للوصول إلى الهدف</string>
 </resources>
 
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -760,6 +760,8 @@
     <string name="ai_popup_title">KI-Assistent</string>
     <string name="ai_hint_input">Wobei möchtest du Hilfe?</string>
     <string name="ai_accept_button">Übernehmen</string>
+    <string name="step_goal_format">/ %1$s Schritte</string>
+    <string name="step_pct_to_goal_format">%1$d%% bis zum Ziel</string>
 </resources>
 
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -759,6 +759,8 @@
     <string name="ai_popup_title">Asistente de IA</string>
     <string name="ai_hint_input">¿En qué te gustaría que te ayudara?</string>
     <string name="ai_accept_button">Aceptar</string>
+    <string name="step_goal_format">/ %1$s pasos</string>
+    <string name="step_pct_to_goal_format">%1$d%% para la meta</string>
 </resources>
 
 

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -756,6 +756,8 @@
     <string name="ai_popup_title">एआई सहायक</string>
     <string name="ai_hint_input">आपको किस चीज़ में मदद चाहिए?</string>
     <string name="ai_accept_button">स्वीकार करें</string>
+    <string name="step_goal_format">/ %1$s कदम</string>
+    <string name="step_pct_to_goal_format">%1$d%% लक्ष्य तक</string>
 
 </resources>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -756,6 +756,8 @@
     <string name="ai_popup_title">Assistente IA</string>
     <string name="ai_hint_input">Con cosa vorresti essere aiutato?</string>
     <string name="ai_accept_button">Accetta</string>
+    <string name="step_goal_format">/ %1$s passi</string>
+    <string name="step_pct_to_goal_format">%1$d%% all\'obiettivo</string>
 
 </resources>
 

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -756,6 +756,8 @@
     <string name="ai_popup_title">AI 어시스턴트</string>
     <string name="ai_hint_input">무엇을 도와드릴까요?</string>
     <string name="ai_accept_button">수락</string>
+    <string name="step_goal_format">/ %1$s 걸음</string>
+    <string name="step_pct_to_goal_format">목표까지 %1$d%%</string>
 
 </resources>
 

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -756,6 +756,8 @@
     <string name="ai_popup_title">AI-assistent</string>
     <string name="ai_hint_input">Waarmee wil je hulp?</string>
     <string name="ai_accept_button">Accepteren</string>
+    <string name="step_goal_format">/ %1$s stappen</string>
+    <string name="step_pct_to_goal_format">%1$d%% tot doel</string>
 
 </resources>
 

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -756,6 +756,8 @@
     <string name="ai_popup_title">Assistente de IA</string>
     <string name="ai_hint_input">Com o que você gostaria de ajuda?</string>
     <string name="ai_accept_button">Aceitar</string>
+    <string name="step_goal_format">/ %1$s passos</string>
+    <string name="step_pct_to_goal_format">%1$d%% para a meta</string>
 
 </resources>
 

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -756,6 +756,8 @@
     <string name="ai_popup_title">Assistente de IA</string>
     <string name="ai_hint_input">Com o que você gostaria de ajuda?</string>
     <string name="ai_accept_button">Aceitar</string>
+    <string name="step_goal_format">/ %1$s passos</string>
+    <string name="step_pct_to_goal_format">%1$d%% para a meta</string>
 
 </resources>
 

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -755,6 +755,8 @@
     <string name="ai_popup_title">Yapay Zeka Asistanı</string>
     <string name="ai_hint_input">Ne konuda yardım istersiniz?</string>
     <string name="ai_accept_button">Kabul Et</string>
+    <string name="step_goal_format">/ %1$s adım</string>
+    <string name="step_pct_to_goal_format">Hedefe %1$d%%</string>
 
 </resources>
 

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -755,6 +755,8 @@
     <string name="ai_popup_title">ШІ-асистент</string>
     <string name="ai_hint_input">З чим би ви хотіли допомогти?</string>
     <string name="ai_accept_button">Прийняти</string>
+    <string name="step_goal_format">/ %1$s кроків</string>
+    <string name="step_pct_to_goal_format">%1$d%% до мети</string>
 </resources>
 
 

--- a/app/src/main/res/values-yo/strings.xml
+++ b/app/src/main/res/values-yo/strings.xml
@@ -756,6 +756,8 @@
     <string name="ai_popup_title">Olùrànlọ́wọ́ AI</string>
     <string name="ai_hint_input">Kí ni o fẹ́ ìrànlọ́wọ́ pẹ̀lú?</string>
     <string name="ai_accept_button">Gbà</string>
+    <string name="step_goal_format">/ %1$s ìṣísẹ̀</string>
+    <string name="step_pct_to_goal_format">%1$d%% sí góòlù</string>
 </resources>
 
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -755,6 +755,8 @@
     <string name="ai_popup_title">AI 助手</string>
     <string name="ai_hint_input">您需要什么帮助？</string>
     <string name="ai_accept_button">接受</string>
+    <string name="step_goal_format">/ %1$s 步</string>
+    <string name="step_pct_to_goal_format">距离目标 %1$d%%</string>
 </resources>
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -741,4 +741,6 @@
     <string name="ai_popup_title">AI Assistant</string>
     <string name="ai_hint_input">What would you like help with?</string>
     <string name="ai_accept_button">Accept</string>
+    <string name="step_goal_format">/ %1$s steps</string>
+    <string name="step_pct_to_goal_format">%1$d%% to goal</string>
 </resources>


### PR DESCRIPTION
## What this does
Fixes a genuine i18n bug in `ChartManager.java`'s `updateRing()` — two user-facing strings were built directly in Java with hardcoded English text instead of string resources:
- `tvGoal.setText("/ " + ... + " steps")`
- `tvPct.setText(progress + "% to goal")`

This affected every step-progress ring in the app (both the regular activity chart and the Health Connect chart use this same method), in every language — users always saw literal English regardless of locale.

## Changes
- Added `step_goal_format` and `step_pct_to_goal_format` string resources with placeholders
- Updated `ChartManager.java` to use `context.getString(...)` instead of hardcoded concatenation
- Translated both strings across all 13 locales

## Notes
- Fixed an unescaped apostrophe in the Italian translation (`all'obiettivo` → `all\'obiettivo`)
- Flagging `yo` (Yoruba) as not native-speaker verified
- Confirmed via `.\gradlew.bat assembleDebug` — build succeeds